### PR TITLE
Initialize project CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable version updates for Go modules
+  - package-ecosystem: "gomod"
+
+    # Look for a `go.mod` file in the `root` directory
+    directory: "/"
+
+    # Default is a maximum of five pull requests for version updates
+    open-pull-requests-limit: 10
+
+    target-branch: "master"
+
+    # Daily update checks; default version checks are performed at 05:00 UTC
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+
+    # Assign everything to me by default
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"
+
+    commit-message:
+      # Prefix all commit messages with "go.mod"
+      prefix: "go.mod"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "ghaw"

--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -1,0 +1,85 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Validate Codebase
+
+# Run builds for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  #push:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_code:
+    name: Lint codebase
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.3
+
+      - name: Remove repo-provided golangci-lint config file
+        run: |
+          # Remove the copy of the config file bundled with the repo/code so
+          # that the configuration provided by the atc0005/go-ci project is
+          # used instead
+          rm -vf .golangci.yml
+
+      - name: Run golangci-lint using container-provided config file settings
+        run: golangci-lint run -v
+
+      # This is the very latest stable version of staticcheck provided by the
+      # atc0005/go-ci container. The version included with golangci-lint often
+      # lags behind the official stable releases.
+      - name: Run staticcheck
+        run: staticcheck $(go list -mod=vendor ./... | grep -v /vendor/)
+
+  test_code:
+    name: Run tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
+
+    container:
+      image: "index.docker.io/atc0005/go-ci:${{ matrix.container-image}}"
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.3
+
+      - name: Run all tests
+        run: go test -mod=vendor -v ./...
+
+  build_code:
+    name: Build codebase
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        container-image: ["go-ci-oldstable", "go-ci-stable", "go-ci-unstable"]
+
+    container:
+      image: "index.docker.io/atc0005/go-ci:${{ matrix.container-image}}"
+
+    steps:
+      - name: Print go version
+        run: go version
+
+      - name: Check out code
+        uses: actions/checkout@v2.3.3
+
+      - name: Build using vendored dependencies
+        run: |
+          go build -v -mod=vendor ./cmd/check_path

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -1,0 +1,75 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Lint and Build using Makefile
+
+# Run builds for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  #push:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_code_with_makefile:
+    name: Lint codebase using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+    container:
+      image: "index.docker.io/golang:latest"
+
+    steps:
+      - name: Print go version
+        run: go version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2.3.3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Install Go linting tools
+        run: make lintinstall
+
+      # NOTE: We are intentionally *not* removing the repo-provided config
+      # file (per GH-281) as this workflow is intended to emulate running the
+      # Makefile via a local dev environment.
+      #
+      # - name: Remove repo-provided golangci-lint config file
+      #   run: |
+      #     # Remove the copy of the config file bundled with the repo/code so
+      #     # that the configuration provided by the atc0005/go-ci project is
+      #     # used instead
+      #     rm -vf .golangci.yml
+
+      - name: Run Go linting tools using project Makefile
+        run: make linting
+
+  build_code_with_makefile:
+    name: Build codebase using Makefile
+    runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
+    container:
+      image: "index.docker.io/golang:latest"
+
+    steps:
+      - name: Print go version
+        run: go version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2.3.3
+
+      # bsdmainutils provides "column" which is used by the Makefile
+      - name: Install Ubuntu packages
+        run: apt-get update && apt-get install -y --no-install-recommends make gcc bsdmainutils
+
+      - name: Build using project Makefile
+        run: make all

--- a/.github/workflows/lint-and-test-only.yml
+++ b/.github/workflows/lint-and-test-only.yml
@@ -1,0 +1,39 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Quick Validation
+
+# Run builds for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  push:
+
+jobs:
+  lint_and_test_code:
+    name: Lint and test using latest stable container
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: index.docker.io/atc0005/go-ci:go-ci-lint-only
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.3
+
+      - name: Remove repo-provided golangci-lint config file
+        run: |
+          # Remove the copy of the config file bundled with the repo/code so
+          # that the configuration provided by the atc0005/go-ci project is
+          # used instead
+          rm -vf .golangci.yml
+
+      - name: Run golangci-lint using container-provided config file settings
+        run: golangci-lint run -v
+
+      - name: Run all tests
+        run: go test -mod=vendor -v ./...

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -1,0 +1,47 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+name: Validate Docs
+
+# Run Workflow for Pull Requests (new, updated)
+# `synchronized` seems to equate to pushing new commits to a linked branch
+# (whether force-pushed or not)
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint_markdown:
+    name: Lint Markdown files
+    runs-on: "ubuntu-latest"
+    # Default: 360 minutes
+    timeout-minutes: 10
+
+    steps:
+      - name: Setup Node
+        # https://github.com/actions/setup-node
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: "14"
+
+      - name: Install Markdown linting tools
+        run: |
+          npm install markdownlint --save-dev
+          npm install -g markdownlint-cli
+
+      - name: Check out code
+        uses: actions/checkout@v2.3.3
+
+      - name: Run Markdown linting tools
+        # The `.markdownlint.yml` file specifies config settings for this
+        # linter, including which linting rules to ignore.
+        #
+        # Note: Explicitly ignoring top-level vendor folder; we do not want
+        # potential linting issues in bundled documentation to fail linting CI
+        # runs for *our* documentation
+        run: |
+          markdownlint '**/*.md' --ignore node_modules --ignore vendor

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+issues:
+  # equivalent CLI flag: --exclude-use-default
+  #
+  # see:
+  #   atc0005/todo#29
+  #   golangci-lint/golangci-lint#1249
+  #   golangci-lint/golangci-lint#413
+  exclude-use-default: false
+
+linters:
+  enable:
+    - depguard
+    - dogsled
+    - dupl
+    - goconst
+    - gocritic
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - maligned
+    - misspell
+    - prealloc
+    - scopelint
+    - stylecheck
+    - unconvert

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,22 @@
+# Copyright 2020 Adam Chalkley
+#
+# https:#github.com/atc0005/check-paths
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://github.com/igorshubovych/markdownlint-cli#configuration
+# https://github.com/DavidAnson/markdownlint#optionsconfig
+
+# Setting the special default rule to true or false includes/excludes all
+# rules by default.
+"default": true
+
+# We know that line lengths will be long in the main README file, so don't
+# report those cases.
+"MD013": false
+
+# Don't complain if sub-heading names are duplicated since this is a common
+# practice in CHANGELOG.md (e.g., "Fixed").
+"MD024":
+  "siblings_only": true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,204 @@
+# Copyright 2020 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# References:
+#
+# https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies
+# https://github.com/mapnik/sphinx-docs/blob/master/Makefile
+# https://stackoverflow.com/questions/23843106/how-to-set-child-process-environment-variable-in-makefile
+# https://stackoverflow.com/questions/3267145/makefile-execute-another-target
+# https://unix.stackexchange.com/questions/124386/using-a-make-rule-to-call-another
+# https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
+# https://www.gnu.org/software/make/manual/html_node/Recipe-Syntax.html#Recipe-Syntax
+# https://www.gnu.org/software/make/manual/html_node/Special-Variables.html#Special-Variables
+# https://danishpraka.sh/2019/12/07/using-makefiles-for-go.html
+# https://gist.github.com/subfuzion/0bd969d08fe0d8b5cc4b23c795854a13
+# https://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
+# https://stackoverflow.com/questions/38801796/makefile-set-if-variable-is-empty
+
+SHELL = /bin/bash
+
+# Space-separated list of cmd/BINARY_NAME directories to build
+WHAT 					= check_path
+
+# TODO: This will need to be standardized across all cmd files in order to
+# work as intended.
+#
+# What package holds the "version" variable used in branding/version output?
+# VERSION_VAR_PKG			= $(shell go list .)
+# VERSION_VAR_PKG			= $(shell go list .)/internal/config
+VERSION_VAR_PKG			= main
+
+OUTPUTDIR 				= release_assets
+
+# https://gist.github.com/TheHippo/7e4d9ec4b7ed4c0d7a39839e6800cc16
+VERSION 				= $(shell git describe --always --long --dirty)
+
+# The default `go build` process embeds debugging information. Building
+# without that debugging information reduces the binary size by around 28%.
+#
+# We also include additional flags in an effort to generate static binaries
+# that do not have external dependencies. As of Go 1.15 this still appears to
+# be a mixed bag, so YMMV.
+#
+# See https://github.com/golang/go/issues/26492 for more information.
+#
+# -s
+#	Omit the symbol table and debug information.
+#
+# -w
+#	Omit the DWARF symbol table.
+#
+# -tags 'osusergo,netgo'
+#	Use pure Go implementation of user and group id/name resolution.
+#	Use pure Go implementation of DNS resolver.
+#
+# -extldflags '-static'
+#	Pass 'static' flag to external linker.
+#
+# -linkmode=external
+#	https://golang.org/src/cmd/cgo/doc.go
+#
+#   NOTE: Using external linker requires installation of `gcc-multilib`
+#   package when building 32-bit binaries on a Debian/Ubuntu system. It also
+#   seems to result in an unstable build that crashes on startup. This *might*
+#   be specific to the WSL environment used for builds, but since this is a
+#   new issue and and I do not yet know much about this option, I am leaving
+#   it out.
+#
+# CGO_ENABLED=0
+#	https://golang.org/cmd/cgo/
+#	explicitly disable use of cgo
+#	removes potential need for linkage against local c library (e.g., glibc)
+BUILDCMD				=	CGO_ENABLED=0 go build -mod=vendor -trimpath -a -ldflags "-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
+GOCLEANCMD				=	go clean -mod=vendor ./...
+GITCLEANCMD				= 	git clean -xfd
+CHECKSUMCMD				=	sha256sum -b
+
+.DEFAULT_GOAL := help
+
+  ##########################################################################
+  # Targets will not work properly if a file with the same name is ever
+  # created in this directory. We explicitly declare our targets to be phony
+  # by making them a prerequisite of the special target .PHONY
+  ##########################################################################
+
+.PHONY: help
+## help: prints this help message
+help:
+	@echo "Usage:"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'
+
+.PHONY: lintinstall
+## lintinstall: install common linting tools
+# https://github.com/golang/go/issues/30515#issuecomment-582044819
+lintinstall:
+	@echo "Installing linting tools"
+
+	@export PATH="${PATH}:$(go env GOPATH)/bin"
+
+	@echo "Explicitly enabling Go modules mode per command"
+	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
+
+	@echo Installing latest stable golangci-lint version per official installation script ...
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
+	golangci-lint --version
+
+	@echo "Finished updating linting tools"
+
+.PHONY: linting
+## linting: runs common linting checks
+linting:
+	@echo "Running linting tools ..."
+
+	@echo "Running go vet ..."
+	@go vet -mod=vendor $(shell go list -mod=vendor ./... | grep -v /vendor/)
+
+	@echo "Running golangci-lint ..."
+	@golangci-lint run
+
+	@echo "Running staticcheck ..."
+	@staticcheck $(shell go list -mod=vendor ./... | grep -v /vendor/)
+
+	@echo "Finished running linting checks"
+
+.PHONY: gotests
+## gotests: runs go test recursively, verbosely
+gotests:
+	@echo "Running go tests ..."
+	@go test -mod=vendor ./...
+	@echo "Finished running go tests"
+
+.PHONY: goclean
+## goclean: removes local build artifacts, temporary files, etc
+goclean:
+	@echo "Removing object files and cached files ..."
+	@$(GOCLEANCMD)
+	@echo "Removing any existing release assets"
+	@mkdir -p "$(OUTPUTDIR)"
+	@rm -vf $(wildcard ${OUTPUTDIR}/*/*-linux-*)
+	@rm -vf $(wildcard ${OUTPUTDIR}/*/*-windows-*)
+
+.PHONY: clean
+## clean: alias for goclean
+clean: goclean
+
+.PHONY: gitclean
+## gitclean: WARNING - recursively cleans working tree by removing non-versioned files
+gitclean:
+	@echo "Removing non-versioned files ..."
+	@$(GITCLEANCMD)
+
+.PHONY: pristine
+## pristine: run goclean and gitclean to remove local changes
+pristine: goclean gitclean
+
+.PHONY: all
+# https://stackoverflow.com/questions/3267145/makefile-execute-another-target
+## all: generates assets for Linux distros and Windows
+all: clean windows linux
+	@echo "Completed all cross-platform builds ..."
+
+.PHONY: windows
+## windows: generates assets for Windows systems
+windows:
+	@echo "Building release assets for windows ..."
+
+	@for target in $(WHAT); do \
+		mkdir -p $(OUTPUTDIR)/$$target && \
+		echo "Building $$target 386 binaries" && \
+		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-windows-386.exe ${PWD}/cmd/$$target && \
+		echo "Building $$target amd64 binaries" && \
+		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-windows-amd64.exe ${PWD}/cmd/$$target && \
+		echo "Generating $$target checksum files" && \
+		cd $(OUTPUTDIR)/$$target && \
+		$(CHECKSUMCMD) $$target-$(VERSION)-windows-386.exe > $$target-$(VERSION)-windows-386.exe.sha256 && \
+		$(CHECKSUMCMD) $$target-$(VERSION)-windows-amd64.exe > $$target-$(VERSION)-windows-amd64.exe.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed build tasks for windows"
+
+.PHONY: linux
+## linux: generates assets for Linux distros
+linux:
+	@echo "Building release assets for linux ..."
+
+	@for target in $(WHAT); do \
+		mkdir -p $(OUTPUTDIR)/$$target && \
+		echo "Building $$target 386 binaries" && \
+		env GOOS=linux GOARCH=386 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-linux-386 ${PWD}/cmd/$$target && \
+		echo "Building $$target amd64 binaries" && \
+		env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-linux-amd64 ${PWD}/cmd/$$target && \
+		echo "Generating $$target checksum files" && \
+		cd $(OUTPUTDIR)/$$target && \
+		$(CHECKSUMCMD) $$target-$(VERSION)-linux-386 > $$target-$(VERSION)-linux-386.sha256 && \
+		$(CHECKSUMCMD) $$target-$(VERSION)-linux-amd64 > $$target-$(VERSION)-linux-amd64.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed build tasks for linux"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,172 @@
+<!-- omit in toc -->
 # check-path
-Go-based tooling to check/verify filesystem paths as part of a Nagios service check
+
+Go-based tooling to check/verify filesystem paths as part of a Nagios service
+check.
+
+[![Latest Release](https://img.shields.io/github/release/atc0005/check-path.svg?style=flat-square)](https://github.com/atc0005/check-path/releases/latest)
+[![GoDoc](https://godoc.org/github.com/atc0005/check-path?status.svg)](https://godoc.org/github.com/atc0005/check-path)
+[![Validate Codebase](https://github.com/atc0005/check-path/workflows/Validate%20Codebase/badge.svg)](https://github.com/atc0005/check-path/actions?query=workflow%3A%22Validate+Codebase%22)
+[![Validate Docs](https://github.com/atc0005/check-path/workflows/Validate%20Docs/badge.svg)](https://github.com/atc0005/check-path/actions?query=workflow%3A%22Validate+Docs%22)
+[![Lint and Build using Makefile](https://github.com/atc0005/check-path/workflows/Lint%20and%20Build%20using%20Makefile/badge.svg)](https://github.com/atc0005/check-path/actions?query=workflow%3A%22Lint+and+Build+using+Makefile%22)
+[![Quick Validation](https://github.com/atc0005/check-path/workflows/Quick%20Validation/badge.svg)](https://github.com/atc0005/check-path/actions?query=workflow%3A%22Quick+Validation%22)
+
+<!-- omit in toc -->
+## Table of Contents
+
+- [Project home](#project-home)
+- [Overview](#overview)
+- [Features](#features)
+- [Changelog](#changelog)
+- [Requirements](#requirements)
+  - [Building source code](#building-source-code)
+  - [Running](#running)
+- [Installation](#installation)
+- [Examples](#examples)
+- [License](#license)
+- [Related projects](#related-projects)
+- [References](#references)
+
+## Project home
+
+See [our GitHub repo](https://github.com/atc0005/check-path) for the latest code,
+to file an issue or submit improvements for review and potential inclusion
+into the project.
+
+## Overview
+
+This repo contains various tools used to verify the ownership, group,
+permissions, age or size of specific files or directories.
+
+## Features
+
+- placeholder
+
+## Changelog
+
+See the [`CHANGELOG.md`](CHANGELOG.md) file for the changes associated with
+each release of this application. Changes that have been merged to `master`,
+but not yet an official release may also be noted in the file under the
+`Unreleased` section. A helpful link to the Git commit history since the last
+official release is also provided for further review.
+
+## Requirements
+
+The following is a loose guideline. Other combinations of Go and operating
+systems for building and running tools from this repo may work, but have not
+been tested.
+
+### Building source code
+
+- Go 1.13+
+- GCC
+  - if building with custom options (as the provided `Makefile` does)
+- `make`
+  - if using the provided `Makefile`
+
+### Running
+
+- Windows 7, Server 2008R2 or later
+  - per official [Go install notes][go-docs-install]
+- Windows 10 Version 1909
+  - tested
+- Ubuntu Linux 16.04, 18.04
+
+## Installation
+
+1. [Download][go-docs-download] Go
+1. [Install][go-docs-install] Go
+   - NOTE: Pay special attention to the remarks about `$HOME/.profile`
+1. Clone the repo
+   1. `cd /tmp`
+   1. `git clone https://github.com/atc0005/check-path`
+   1. `cd check-path`
+1. Install dependencies (optional)
+   - for Ubuntu Linux
+     - `sudo apt-get install make gcc`
+   - for CentOS Linux
+     - `sudo yum install make gcc`
+   - for Windows
+     - Emulated environments (*easier*)
+       - Skip all of this and build using the default `go build` command in
+         Windows (see below for use of the `-mod=vendor` flag)
+       - build using Windows Subsystem for Linux Ubuntu environment and just
+         copy out the Windows binaries from that environment
+       - If already running a Docker environment, use a container with the Go
+         tool-chain already installed
+       - If already familiar with LXD, create a container and follow the
+         installation steps given previously to install required dependencies
+     - Native tooling (*harder*)
+       - see the StackOverflow Question `32127524` link in the
+         [References](references.md) section for potential options for
+         installing `make` on Windows
+       - see the mingw-w64 project homepage link in the
+         [References](references.md) section for options for installing `gcc`
+         and related packages on Windows
+1. Build binaries
+   - for the current operating system, explicitly using bundled dependencies
+         in top-level `vendor` folder
+     - `go build -mod=vendor ./cmd/check_path/`
+   - for all supported platforms (where `make` is installed)
+      - `make all`
+   - for use on Windows
+      - `make windows`
+   - for use on Linux
+     - `make linux`
+1. Copy the newly compiled binary from the applicable `/tmp` subdirectory path
+   (based on the clone instructions in this section) below and deploy where
+   needed.
+   - if using `Makefile`
+     - look in `/tmp/check-path/release_assets/check_path/`
+   - if using `go build`
+     - look in `/tmp/check-path/`
+
+## Examples
+
+- placeholder
+
+## License
+
+```license
+MIT License
+
+Copyright (c) 2020 Adam Chalkley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Related projects
+
+- <https://github.com/atc0005/elbow>
+- <https://github.com/atc0005/go-nagios>
+
+## References
+
+- <https://github.com/rs/zerolog>
+- <https://github.com/atc0005/go-nagios>
+- <https://nagios-plugins.org/doc/guidelines.html>
+
+<!-- Footnotes here  -->
+
+[repo-url]: <https://github.com/atc0005/check-path>  "This project's GitHub repo"
+
+[go-docs-download]: <https://golang.org/dl>  "Download Go"
+
+[go-docs-install]: <https://golang.org/doc/install>  "Install Go"
+
+<!-- []: PLACEHOLDER "DESCRIPTION_HERE" -->

--- a/cmd/check_path/main.go
+++ b/cmd/check_path/main.go
@@ -1,0 +1,16 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello prototype project!")
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// TODO: Add content here
+package main

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+module github.com/atc0005/check-path
+
+go 1.14


### PR DESCRIPTION
- Add GitHub Actions Workflows
- Add Makefile
- Initialize Go module
- Add stub main.go file to satisfy build requirements
- Add Dependabot configuration
- Add golangci-lint configuration
- Add markdownlint configuration

Content has been heavily borrowed from the atc0005/check-cert
project.