### PR TITLE
Fix doc comment breadcrumb URL

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,6 @@
 # Copyright 2020 Adam Chalkley
 #
-# https:#github.com/atc0005/check-paths
+# https:#github.com/atc0005/check-path
 #
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.


### PR DESCRIPTION
Typo introduced at some point for repo URL.