### PR TITLE
Break size logic into min and max threshold sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ alerts generated from check results have a common theme.
 - Age checks
   - `CRITICAL` and `WARNING` thresholds
 - Size checks
-  - `CRITICAL` and `WARNING` thresholds
+  - minimum `CRITICAL` and `WARNING` thresholds
+    - e.g., "path required to be X size or larger"
+  - maximum `CRITICAL` and `WARNING` thresholds
+    - e.g., "path required to be X size or smaller"
 - Username checks
   - `CRITICAL` or `WARNING` (as specified) if missing
   - **NOTE**: this check is not supported on Windows
@@ -224,8 +227,10 @@ sysadmin, though some (e.g., logging) have useful defaults.
 | `fail-fast`                   | No       | `false`      | No     | `true`, `false`                                                         | Whether this plugin prioritizes speed of check results over always returning a `CRITICAL` state result before a `WARNING` state. This can be useful for processing large collections of content. |
 | `age-critical`                | No       | `0`          | No     | `2+` (*minimum 1 greater than warning*)                                 | Assert that age for specified paths is less than or equal to the specified age in days, otherwise consider state to be `CRITICAL`.                                                               |
 | `age-warning`                 | No       | `0`          | No     | `1+` (*minimum of 1*)                                                   | Assert that age for specified paths is less than or equal to the specified age in days, otherwise consider state to be `WARNING`.                                                                |
-| `size-critical`               | No       | `0`          | No     | `2+` (*minimum 1 greater than warning*)                                 | Assert that size for specified paths is less than or equal to the specified size in bytes, otherwise consider state to be `CRITICAL`.                                                            |
-| `size-warning`                | No       | `0`          | No     | `1+` (*minimum of 1*)                                                   | Assert that size for specified paths is less than or equal to the specified size in bytes, otherwise consider state to be `WARNING`.                                                             |
+| `size-min-critical`           | No       | `0`          | No     | `2+` (*minimum 1 greater than size-min-warning*)                        | Assert that size for specified paths is the specified size in bytes or greater, otherwise consider state to be `CRITICAL`.                                                                       |
+| `size-min-warning`            | No       | `0`          | No     | `1+` (*minimum of 1*)                                                   | Assert that size for specified paths is the specified size in bytes or greater, otherwise consider state to be `WARNING`.                                                                        |
+| `size-max-critical`           | No       | `0`          | No     | `2+` (*minimum 1 greater than size-max-warning*)                        | Assert that size for specified paths is the specified size in bytes or less, otherwise consider state to be `CRITICAL`.                                                                          |
+| `size-max-warning`            | No       | `0`          | No     | `1+` (*minimum of 1*)                                                   | Assert that size for specified paths is the specified size in bytes or less , otherwise consider state to be `WARNING`.                                                                          |
 | `exists-critical`             | No       | `false`      | No     | `true`, `false`                                                         | Assert that specified paths are missing, otherwise consider state to be `CRITICAL`.                                                                                                              |
 | `exists-warning`              | No       | `false`      | No     | `true`, `false`                                                         | Assert that specified paths are missing, otherwise consider state to be `WARNING`.                                                                                                               |
 | `username-missing-critical`   | No       | `false`      | No     | *valid username*   (**not supported on Windows**)                       | Assert that specified owner/username is present on all content in specified paths, otherwise consider state to be `CRITICAL`.                                                                    |
@@ -249,8 +254,10 @@ for more information.
 | `fail-fast`                   | `CHECK_PATH_FAIL_FAST`                   |       | `CHECK_PATH_FAIL_FAST="false"`                            |
 | `age-critical`                | `CHECK_PATH_AGE_CRITICAL`                |       | `CHECK_PATH_AGE_CRITICAL="2"`                             |
 | `age-warning`                 | `CHECK_PATH_AGE_WARNING`                 |       | `CHECK_PATH_AGE_WARNING="1"`                              |
-| `size-critical`               | `CHECK_PATH_SIZE_CRITICAL`               |       | `CHECK_PATH_SIZE_CRITICAL="2"`                            |
-| `size-warning`                | `CHECK_PATH_SIZE_WARNING`                |       | `CHECK_PATH_SIZE_WARNING="1"`                             |
+| `size-min-critical`           | `CHECK_PATH_SIZE_MIN_CRITICAL`           |       | `CHECK_PATH_SIZE_MIN_CRITICAL="2"`                        |
+| `size-min-warning`            | `CHECK_PATH_SIZE_MIN_WARNING`            |       | `CHECK_PATH_SIZE_MIN_WARNING="1"`                         |
+| `size-max-critical`           | `CHECK_PATH_SIZE_MAX_CRITICAL`           |       | `CHECK_PATH_SIZE_MAX_CRITICAL="2"`                        |
+| `size-max-warning`            | `CHECK_PATH_SIZE_MAX_WARNING`            |       | `CHECK_PATH_SIZE_MAX_WARNING="1"`                         |
 | `exists-critical`             | `CHECK_PATH_EXISTS_CRITICAL`             |       | `CHECK_PATH_EXISTS_CRITICAL="true"`                       |
 | `exists-warning`              | `CHECK_PATH_EXISTS_WARNING`              |       | `CHECK_PATH_EXISTS_WARNING="true"`                        |
 | `username-missing-critical`   | `CHECK_PATH_USERNAME_MISSING_CRITICAL`   |       | `CHECK_PATH_USERNAME_MISSING_CRITICAL="ubuntu"`           |

--- a/cmd/check_path/thresholds.go
+++ b/cmd/check_path/thresholds.go
@@ -69,12 +69,12 @@ func setThresholdDescriptions(cfg *config.Config, nes *nagios.ExitState) {
 
 	}
 
-	if size := cfg.Size(); size.Set {
+	if sizeMin := cfg.SizeMin(); sizeMin.Set {
 
-		sizeCriticalThreshold := fmt.Sprintf(
-			"[File size (bytes: %d, Human: %s)]",
-			size.Critical,
-			units.ByteCountIEC(size.Critical),
+		sizeMinCriticalThreshold := fmt.Sprintf(
+			"[Min File size (bytes: %d, Human: %s)]",
+			sizeMin.Critical,
+			units.ByteCountIEC(sizeMin.Critical),
 		)
 
 		switch {
@@ -82,18 +82,18 @@ func setThresholdDescriptions(cfg *config.Config, nes *nagios.ExitState) {
 			nes.CriticalThreshold = strings.Join(
 				[]string{
 					nes.CriticalThreshold,
-					sizeCriticalThreshold,
+					sizeMinCriticalThreshold,
 				},
 				", ",
 			)
 		default:
-			nes.CriticalThreshold = sizeCriticalThreshold
+			nes.CriticalThreshold = sizeMinCriticalThreshold
 		}
 
-		sizeWarningThreshold := fmt.Sprintf(
-			"[File size (bytes: %d, Human: %s)]",
-			size.Warning,
-			units.ByteCountIEC(size.Warning),
+		sizeMinWarningThreshold := fmt.Sprintf(
+			"[Min File size (bytes: %d, Human: %s)]",
+			sizeMin.Warning,
+			units.ByteCountIEC(sizeMin.Warning),
 		)
 
 		switch {
@@ -101,12 +101,54 @@ func setThresholdDescriptions(cfg *config.Config, nes *nagios.ExitState) {
 			nes.WarningThreshold = strings.Join(
 				[]string{
 					nes.WarningThreshold,
-					sizeWarningThreshold,
+					sizeMinWarningThreshold,
 				},
 				", ",
 			)
 		default:
-			nes.WarningThreshold = sizeWarningThreshold
+			nes.WarningThreshold = sizeMinWarningThreshold
+		}
+
+	}
+
+	if sizeMax := cfg.SizeMax(); sizeMax.Set {
+
+		sizeMaxCriticalThreshold := fmt.Sprintf(
+			"[Max File size (bytes: %d, Human: %s)]",
+			sizeMax.Critical,
+			units.ByteCountIEC(sizeMax.Critical),
+		)
+
+		switch {
+		case nes.CriticalThreshold != "":
+			nes.CriticalThreshold = strings.Join(
+				[]string{
+					nes.CriticalThreshold,
+					sizeMaxCriticalThreshold,
+				},
+				", ",
+			)
+		default:
+			nes.CriticalThreshold = sizeMaxCriticalThreshold
+		}
+
+		sizeMaxWarningThreshold := fmt.Sprintf(
+			"[Max File size (bytes: %d, Human: %s)]",
+			sizeMax.Warning,
+			units.ByteCountIEC(sizeMax.Warning),
+		)
+
+		switch {
+		case nes.WarningThreshold != "":
+			nes.WarningThreshold = strings.Join(
+				[]string{
+					nes.WarningThreshold,
+					sizeMaxWarningThreshold,
+				},
+				", ",
+			)
+		default:
+			nes.WarningThreshold = sizeMaxWarningThreshold
 		}
 
 	}

--- a/doc.go
+++ b/doc.go
@@ -25,7 +25,7 @@ FEATURES
 
 • Age checks: CRITICAL and WARNING thresholds
 
-• Size checks: CRITICAL and WARNING thresholds
+• Size checks: minimum and maximum CRITICAL and WARNING thresholds
 
 • Existence checks: CRITICAL or WARNING (as specified) if present
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,7 +47,8 @@ func (c Config) String() string {
 			"MissingOK: %v, "+
 			"EmitBranding: %v, "+
 			"Age: [Critical: %v, Warning: %v, Set: %v], "+
-			"Size: [Critical: %v, Warning: %v, Set: %v], "+
+			"SizeMin: [Critical: %v, Warning: %v, Set: %v], "+
+			"SizeMax: [Critical: %v, Warning: %v, Set: %v], "+
 			"PathExists: [Critical: %v, Warning: %v], "+
 			"User: [Name: %q, Critical: %v, Warning: %v], "+
 			"Group: [Name: %q, Critical: %v, Warning: %v] }",
@@ -59,9 +60,12 @@ func (c Config) String() string {
 		c.Age().Critical,
 		c.Age().Warning,
 		c.Age().Set,
-		c.Size().Critical,
-		c.Size().Warning,
-		c.Size().Set,
+		c.SizeMin().Critical,
+		c.SizeMin().Warning,
+		c.SizeMin().Set,
+		c.SizeMax().Critical,
+		c.SizeMax().Warning,
+		c.SizeMax().Set,
 		c.PathExistsCritical(),
 		c.PathExistsWarning(),
 		c.Username(),

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -32,3 +32,9 @@ const (
 	defaultUsername  string = ""
 	defaultGroupName string = ""
 )
+
+// used by SizeMin and SizeMax getter methods for threshold descriptions
+const (
+	sizeMinDescription string = "minimum"
+	sizeMaxDescription string = "maximum"
+)

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -95,15 +95,34 @@ func (c Config) Age() FileAgeThresholds {
 	}
 }
 
-// Size returns the user-provided CRITICAL and WARNING thresholds in bytes for
-// the specified paths.
-func (c Config) Size() FileSizeThresholds {
+// SizeMin returns the user-provided CRITICAL and WARNING thresholds for
+// minimum size in bytes for the specified paths.
+func (c Config) SizeMin() FileSizeThresholds {
 	switch {
-	case c.Search.SizeCritical != nil && c.Search.SizeWarning != nil:
+	case c.Search.SizeMinCritical != nil && c.Search.SizeMinWarning != nil:
 		return FileSizeThresholds{
-			Critical: *c.Search.SizeCritical,
-			Warning:  *c.Search.SizeWarning,
-			Set:      true,
+			Description: sizeMinDescription,
+			Critical:    *c.Search.SizeMinCritical,
+			Warning:     *c.Search.SizeMinWarning,
+			Set:         true,
+		}
+	default:
+		return FileSizeThresholds{
+			Set: false,
+		}
+	}
+}
+
+// SizeMax returns the user-provided CRITICAL and WARNING thresholds for
+// maximum size in bytes for the specified paths.
+func (c Config) SizeMax() FileSizeThresholds {
+	switch {
+	case c.Search.SizeMaxCritical != nil && c.Search.SizeMaxWarning != nil:
+		return FileSizeThresholds{
+			Description: sizeMaxDescription,
+			Critical:    *c.Search.SizeMaxCritical,
+			Warning:     *c.Search.SizeMaxWarning,
+			Set:         true,
 		}
 	default:
 		return FileSizeThresholds{

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -23,9 +23,10 @@ type FileAgeThresholds struct {
 // FileSizeThresholds represents the user-specified file size thresholds for
 // specified paths.
 type FileSizeThresholds struct {
-	Critical int64
-	Warning  int64
-	Set      bool
+	Description string
+	Critical    int64
+	Warning     int64
+	Set         bool
 }
 
 // Search represents options specific to controlling how this application
@@ -37,8 +38,10 @@ type Search struct {
 	FailFast                 *bool    `arg:"--fail-fast,env:CHECK_PATH_FAIL_FAST" help:"Whether this plugin prioritizes speed of check results over always returning a CRITICAL state result before a WARNING state. This can be useful for processing large collections of content."`
 	AgeCritical              *int     `arg:"--age-critical,env:CHECK_PATH_AGE_CRITICAL" help:"Assert that age for specified paths is less than or equal to the specified age in days, otherwise consider state to be CRITICAL."`
 	AgeWarning               *int     `arg:"--age-warning,env:CHECK_PATH_AGE_WARNING" help:"Assert that age for specified paths is less than or equal to the specified age in days, otherwise consider state to be WARNING."`
-	SizeCritical             *int64   `arg:"--size-critical,env:CHECK_PATH_SIZE_CRITICAL" help:"Assert that size for specified paths is less than or equal to the specified size in bytes, otherwise consider state to be CRITICAL."`
-	SizeWarning              *int64   `arg:"--size-warning,env:CHECK_PATH_SIZE_WARNING" help:"Assert that size for specified paths is less than or equal to the specified size in bytes, otherwise consider state to be WARNING."`
+	SizeMinCritical          *int64   `arg:"--size-min-critical,env:CHECK_PATH_SIZE_MIN_CRITICAL" help:"Assert that size for specified paths is the specified size in bytes or greater, otherwise consider state to be CRITICAL."`
+	SizeMinWarning           *int64   `arg:"--size-min-warning,env:CHECK_PATH_SIZE_MIN_WARNING" help:"Assert that size for specified paths is the specified size in bytes or greater, otherwise consider state to be WARNING."`
+	SizeMaxCritical          *int64   `arg:"--size-max-critical,env:CHECK_PATH_SIZE_MAX_CRITICAL" help:"Assert that size for specified paths is the specified size in bytes or less, otherwise consider state to be CRITICAL."`
+	SizeMaxWarning           *int64   `arg:"--size-max-warning,env:CHECK_PATH_SIZE_MAX_WARNING" help:"Assert that size for specified paths is the specified size in bytes or less , otherwise consider state to be WARNING."`
 	ExistsCritical           *bool    `arg:"--exists-critical,env:CHECK_PATH_EXISTS_CRITICAL" help:"Assert that specified paths are missing, otherwise consider state to be CRITICAL."`
 	ExistsWarning            *bool    `arg:"--exists-warning,env:CHECK_PATH_EXISTS_WARNING" help:"Assert that specified paths are missing, otherwise consider state to be WARNING."`
 	UsernameMissingCritical  *string  `arg:"--username-missing-critical,env:CHECK_PATH_USERNAME_MISSING_CRITICAL" help:"Assert that specified owner/username is present on all content in specified paths, otherwise consider state to be CRITICAL."`


### PR DESCRIPTION
- minimum size set: CRITICAL & WARNING
- maximum size set: CRITICAL, WARNING

Either or both of minimum and maximum file size can be
specified, but as before, if you specify a CRITICAL
threshold value, you must also supply the WARNING
threshold value (and vice versa).

fixes GH-23