### PR TITLE
Add option to ignore paths

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -34,7 +34,11 @@ FEATURES
 • Group Name checks: CRITICAL or WARNING (as specified) if missing
 
 • Optional directory recursion
+
 • Optional "missing OK" toggle, compatible with most checks
+
+• Optional exclusion of specific paths from evaluation
+
 • Optional "fail fast" behavior in an effort to avoid I/O churn over deep paths. See "Known issues" section of README for potential issues with this option.
 
 USAGE

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,8 @@ func Branding(msg string) func() string {
 // initialized (user-provided or default) values.
 func (c Config) String() string {
 	return fmt.Sprintf(
-		"{ Paths: %v, "+
+		"{ PathsInclude: %v, "+
+			"PathsExclude: %v, "+
 			"LogLevel: %v, "+
 			"Recursive: %v, "+
 			"MissingOK: %v, "+
@@ -52,7 +53,8 @@ func (c Config) String() string {
 			"PathExists: [Critical: %v, Warning: %v], "+
 			"User: [Name: %q, Critical: %v, Warning: %v], "+
 			"Group: [Name: %q, Critical: %v, Warning: %v] }",
-		c.Paths(),
+		c.PathsInclude(),
+		c.PathsExclude(),
 		c.LogLevel(),
 		c.Recursive(),
 		c.MissingOK(),

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -7,15 +7,45 @@
 
 package config
 
-// Paths returns the user-provided list of paths to check or an empty list if
-// a user-specified list of paths was not provided.
-func (c Config) Paths() []string {
+import "path/filepath"
+
+// PathsInclude returns the user-provided list of paths to check or an empty
+// list if a user-specified list of paths was not provided. Each path in the
+// list is processed by filepath.Clean. This allows for more reliable
+// comparison against PathsExclude values to determine if a path should be
+// ignored.
+func (c Config) PathsInclude() []string {
 	switch {
-	case c.Search.Paths != nil:
-		return c.Search.Paths
+	case c.Search.PathsInclude != nil:
+		cleanedPaths := make([]string, len(c.Search.PathsInclude))
+		for i, path := range c.Search.PathsInclude {
+			cleanedPaths[i] = filepath.Clean(path)
+		}
+
+		return cleanedPaths
 	default:
-		// this will probably not be reached due to Config.validate() ensuring
+		// this will probably not be reached due to validation checks ensuring
 		// that a value was provided
+		return []string{}
+	}
+}
+
+// PathsExclude returns the user-provided list of paths to ignore or an empty
+// list if a user-specified list of paths was not provided. Each path in the
+// list is processed by filepath.Clean. This allows for more reliable
+// comparison against PathsInclude values to determine if a path should be
+// ignored.
+func (c Config) PathsExclude() []string {
+	switch {
+	case c.Search.PathsExclude != nil:
+		cleanedPaths := make([]string, len(c.Search.PathsExclude))
+		for i, path := range c.Search.PathsExclude {
+			cleanedPaths[i] = filepath.Clean(path)
+		}
+
+		return cleanedPaths
+
+	default:
 		return []string{}
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -32,7 +32,8 @@ type FileSizeThresholds struct {
 // Search represents options specific to controlling how this application
 // performs searches in the filesystem.
 type Search struct {
-	Paths                    []string `arg:"--paths,env:CHECK_PATH_PATHS_LIST" help:"List of comma or space-separated paths to process."`
+	PathsInclude             []string `arg:"--paths,env:CHECK_PATH_PATHS_INCLUDE" help:"List of comma or space-separated paths to check."`
+	PathsExclude             []string `arg:"--ignore,env:CHECK_PATH_PATHS_IGNORE" help:"List of comma or space-separated paths to ignore. Does not apply to existence checks."`
 	Recursive                *bool    `arg:"--recurse,env:CHECK_PATH_RECURSE" help:"Perform recursive search into subdirectories per provided path."`
 	MissingOK                *bool    `arg:"--missing-ok,env:CHECK_PATH_MISSING_OK" help:"Whether a missing path is considered OK. Incompatible with exists-critical or exists-warning options."`
 	FailFast                 *bool    `arg:"--fail-fast,env:CHECK_PATH_FAIL_FAST" help:"Whether this plugin prioritizes speed of check results over always returning a CRITICAL state result before a WARNING state. This can be useful for processing large collections of content."`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -159,9 +159,12 @@ func pathSizeValidation(ths FileSizeThresholds, sizeCritical *int64, sizeWarning
 // validation.
 func (c Config) validate() error {
 
-	if c.Search.Paths == nil {
+	if c.Search.PathsInclude == nil {
 		return fmt.Errorf("one or more paths not provided")
 	}
+
+	// TODO: Search.PathsExclude - how to handle this one? The file or
+	// directory not existing should not be treated as a problem.
 
 	switch c.LogLevel() {
 	case LogLevelDisabled:

--- a/internal/textutils/doc.go
+++ b/internal/textutils/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Package textutils is an internal package that contains helper functions for
+// working with common text structures.
+package textutils

--- a/internal/textutils/inlist.go
+++ b/internal/textutils/inlist.go
@@ -1,0 +1,19 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package textutils
+
+// InList is a helper function to emulate Python's `if "x"
+// in list:` functionality
+func InList(needle string, haystack []string) bool {
+	for _, item := range haystack {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- Add flag for ignoring list of paths
  - NOTE: This does not apply to "existence" checks
- Report ignored paths via summary output
- Sanitize paths for comparison
  - list of paths to include/process
  - list of paths to exclude/ignore
- Related doc updates

fixes GH-4