### PR TITLE
Restore missing LongServiceOutput path info

### DIFF
--- a/cmd/check_path/main.go
+++ b/cmd/check_path/main.go
@@ -271,6 +271,17 @@ func main() {
 						path,
 					)
 
+					nagiosExitState.LongServiceOutput += fmt.Sprintf(
+						"* Size %s** path: %q%s** bytes: %v%s** human-readable: %v%s",
+						nagios.CheckOutputEOL,
+						path,
+						nagios.CheckOutputEOL,
+						actualSizeBytes,
+						nagios.CheckOutputEOL,
+						actualSizeHR,
+						nagios.CheckOutputEOL,
+					)
+
 					// configure exit state details based on how the
 					// thresholds were crossed. return after all exit state
 					// details are recorded


### PR DESCRIPTION
This was unintentionally removed with recent refactoring work.