### PR TITLE
Refactor checks, fix fail-fast logic

### DIFF
--- a/cmd/check_path/age.go
+++ b/cmd/check_path/age.go
@@ -1,0 +1,107 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/atc0005/check-path/internal/config"
+	"github.com/atc0005/check-path/internal/paths"
+	"github.com/atc0005/go-nagios"
+	"github.com/rs/zerolog"
+)
+
+// checkAge is a helper variadic function that accepts one or many MetaRecord
+// values for age evaluation. If the specified age threshold values are
+// crossed, the provided *nagios.ExitState is updated and an error is returned
+// to signal that this specific check has found old files.
+func checkAge(path string, ths config.FileAgeThresholds, zlog *zerolog.Logger, nes *nagios.ExitState, mrs ...paths.MetaRecord) error {
+
+	// type conversion to expose desired methods
+	metaRecords := paths.MetaRecords(mrs)
+
+	// sort if more than one entry
+	if len(mrs) > 1 {
+		metaRecords.SortByModTimeAsc()
+	}
+
+	for _, record := range metaRecords {
+
+		// skip age check for directories
+		if record.IsDir() {
+			continue
+		}
+
+		criticalAgeFile := paths.AgeExceeded(
+			record.FileInfo, ths.Critical)
+
+		warningAgeFile := paths.AgeExceeded(
+			record.FileInfo, ths.Warning)
+
+		if criticalAgeFile || warningAgeFile {
+			zlog.Error().Err(paths.ErrPathOldFilesFound).
+				Int("critical_age_days", ths.Critical).
+				Int("warning_age_days", ths.Warning).
+				Bool("age_check_enabled", ths.Set).
+				Str("path", path).
+				Msg("old files found")
+
+			nes.LastError = fmt.Errorf(
+				"%d files & directories evaluated: %w",
+				len(metaRecords),
+				paths.ErrPathOldFilesFound,
+			)
+
+			fileAge := time.Since(record.ModTime()).Hours() / 24
+
+			nes.LongServiceOutput += fmt.Sprintf(
+				"* File %s** parent dir: %q%s** name: %q%s** age: %v%s",
+				nagios.CheckOutputEOL,
+				record.ParentDir,
+				nagios.CheckOutputEOL,
+				record.Name(),
+				nagios.CheckOutputEOL,
+				fileAge,
+				nagios.CheckOutputEOL,
+			)
+
+			switch {
+			case criticalAgeFile:
+				nes.ServiceOutput = fmt.Sprintf(
+					"%s: file older than %d days (%.2f) found [path: %q]",
+					nagios.StateCRITICALLabel,
+					ths.Critical,
+					fileAge,
+					path,
+				)
+
+				nes.ExitStatusCode = nagios.StateCRITICALExitCode
+
+				return paths.ErrPathOldFilesFound
+
+			case warningAgeFile:
+				nes.ServiceOutput = fmt.Sprintf(
+					"%s: file older than %d days (%.2f) found [path: %q]",
+					nagios.StateWARNINGLabel,
+					ths.Warning,
+					fileAge,
+					path,
+				)
+
+				nes.ExitStatusCode = nagios.StateWARNINGExitCode
+
+				return paths.ErrPathOldFilesFound
+			}
+
+		}
+	}
+
+	return nil
+
+}

--- a/cmd/check_path/exists.go
+++ b/cmd/check_path/exists.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func checkPaths(list []string, critical bool, warning bool, zlog *zerolog.Logger, nes *nagios.ExitState) {
+func checkExists(list []string, critical bool, warning bool, zlog *zerolog.Logger, nes *nagios.ExitState) {
 
 	pathInfo, err := paths.AssertNotExists(list)
 

--- a/cmd/check_path/ids.go
+++ b/cmd/check_path/ids.go
@@ -1,0 +1,141 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/atc0005/check-path/internal/config"
+	"github.com/atc0005/check-path/internal/paths"
+	"github.com/atc0005/go-nagios"
+	"github.com/rs/zerolog"
+)
+
+// checkIDs is a helper variadic function that accepts one or many MetaRecord
+// values for username, group name evaluation. If the specified values are not
+// present, the provided *nagios.ExitState is updated and an error is returned
+// to signal that this specific check has found missing username or group name
+// values.
+func checkIDs(path string, resolveIDs config.ResolveIDs, zlog *zerolog.Logger, nes *nagios.ExitState, mrs ...paths.MetaRecord) error {
+
+	// G601: Implicit memory aliasing in for loop. (gosec)
+	// for _, record := range mrs {
+
+	for i := range mrs {
+
+		// Avoid taking the address of a loop variable and instead use
+		// indexing to get at the original memory address for use with
+		// paths.ResolveIDs
+		// G601: Implicit memory aliasing in for loop. (gosec)
+		// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
+		record := mrs[i]
+
+		zlog.Debug().Msg("Username, Group name resolution enabled")
+
+		resolveErr := paths.ResolveIDs(&record)
+		if resolveErr != nil {
+			zlog.Error().Err(resolveErr).
+				Str("path", path).
+				Msg(resolveErr.Error())
+
+			nes.LastError = resolveErr
+			nes.ServiceOutput = fmt.Sprintf(
+				"%s: failed to resolve IDs: %v [path: %q]",
+				nagios.StateCRITICALLabel,
+				resolveErr.Error(),
+				path,
+			)
+
+			return resolveErr
+		}
+
+		if resolveIDs.UsernameCheck &&
+			record.Username != resolveIDs.Username {
+
+			statusMsg := fmt.Sprintf(
+				"found username %q; expected %q [path: %q]",
+				record.Username,
+				resolveIDs.Username,
+				record.FQPath,
+			)
+
+			zlog.Error().Err(paths.ErrPathMissingUsername).
+				Bool("username_check_enabled", resolveIDs.UsernameCheck).
+				Bool("group_name_check_enabled", resolveIDs.GroupNameCheck).
+				Str("path", path).
+				Msg(statusMsg)
+
+			nes.LastError = paths.ErrPathMissingUsername
+
+			switch {
+			case resolveIDs.UsernameCritical:
+				nes.ServiceOutput = fmt.Sprintf(
+					"%s: %s",
+					nagios.StateCRITICALLabel,
+					statusMsg,
+				)
+				nes.ExitStatusCode = nagios.StateCRITICALExitCode
+
+				return paths.ErrPathMissingUsername
+
+			case resolveIDs.UsernameWarning:
+				nes.ServiceOutput = fmt.Sprintf(
+					"%s: %s",
+					nagios.StateWARNINGLabel,
+					statusMsg,
+				)
+				nes.ExitStatusCode = nagios.StateWARNINGExitCode
+
+				return paths.ErrPathMissingUsername
+			}
+		}
+
+		if resolveIDs.GroupNameCheck &&
+			record.GroupName != resolveIDs.GroupName {
+
+			statusMsg := fmt.Sprintf(
+				"found group name %q; expected %q [path: %q]",
+				record.GroupName,
+				resolveIDs.GroupName,
+				record.FQPath,
+			)
+
+			zlog.Error().Err(paths.ErrPathMissingGroupName).
+				Bool("username_check_enabled", resolveIDs.UsernameCheck).
+				Bool("group_name_check_enabled", resolveIDs.GroupNameCheck).
+				Str("path", path).
+				Msg(statusMsg)
+
+			nes.LastError = paths.ErrPathMissingGroupName
+
+			switch {
+			case resolveIDs.GroupNameCritical:
+				nes.ServiceOutput = fmt.Sprintf(
+					"%s: %s",
+					nagios.StateCRITICALLabel,
+					statusMsg,
+				)
+				nes.ExitStatusCode = nagios.StateCRITICALExitCode
+
+				return paths.ErrPathMissingGroupName
+
+			case resolveIDs.GroupNameWarning:
+				nes.ServiceOutput = fmt.Sprintf(
+					"%s: %s",
+					nagios.StateWARNINGLabel,
+					statusMsg,
+				)
+				nes.ExitStatusCode = nagios.StateWARNINGExitCode
+
+				return paths.ErrPathMissingGroupName
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/check_path/size.go
+++ b/cmd/check_path/size.go
@@ -1,0 +1,155 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/atc0005/check-path/internal/config"
+	"github.com/atc0005/check-path/internal/paths"
+	"github.com/atc0005/go-nagios"
+	"github.com/rs/zerolog"
+)
+
+// checkSize is a helper variadic function that accepts one or many MetaRecord
+// values for size evaluation. If the specified size threshold values are
+// crossed, the provided *nagios.ExitState is updated and an error is returned
+// to signal that this specific check has found files which exceed specified
+// size values (either too small or too large).
+func checkSize(path string, ths config.FileSizeThresholdsMinMax, zlog *zerolog.Logger, nes *nagios.ExitState, mrs ...paths.MetaRecord) error {
+
+	// type conversion to expose desired methods
+	metaRecords := paths.MetaRecords(mrs)
+
+	// sort if more than one entry
+	if len(mrs) > 1 {
+		metaRecords.SortBySizeAsc()
+	}
+
+	// NOTE: Directories (themselves) are not included in the size values,
+	// just the contents of said directories.
+	actualSizeHR := metaRecords.TotalFileSizeHR()
+	actualSizeBytes := metaRecords.TotalFileSize()
+
+	// warning threshold required, so we can use that to reduce
+	// conditional check logic complexity
+	if (ths.SizeMin.Set && actualSizeBytes < ths.SizeMin.Warning) ||
+		(ths.SizeMax.Set && actualSizeBytes > ths.SizeMax.Warning) {
+
+		sizeOfFilesTooLargeErr := fmt.Errorf(
+			"%w (%d evaluated)",
+			paths.ErrSizeOfFilesTooLarge,
+			len(metaRecords),
+		)
+
+		sizeOfFilesTooSmallErr := fmt.Errorf(
+			"%w (%d evaluated)",
+			paths.ErrSizeOfFilesTooSmall,
+			len(metaRecords),
+		)
+
+		serviceOutputTmpl := fmt.Sprintf(
+			"size threshold crossed; %v found in path %q",
+			actualSizeHR,
+			path,
+		)
+
+		nes.LongServiceOutput += fmt.Sprintf(
+			"* Size %s** path: %q%s** bytes: %v%s** human-readable: %v%s",
+			nagios.CheckOutputEOL,
+			path,
+			nagios.CheckOutputEOL,
+			actualSizeBytes,
+			nagios.CheckOutputEOL,
+			actualSizeHR,
+			nagios.CheckOutputEOL,
+		)
+
+		var stateLabel string
+		var exitCode int
+
+		// configure exit state details based on how the
+		// thresholds were crossed. return after all exit state
+		// details are recorded
+		switch {
+
+		case ths.SizeMax.Set &&
+			(actualSizeBytes > ths.SizeMax.Critical || actualSizeBytes > ths.SizeMax.Warning):
+			zlog.Error().Err(sizeOfFilesTooLargeErr).
+				Int64("critical_size_max_bytes", ths.SizeMax.Critical).
+				Int64("warning_size_max_bytes", ths.SizeMax.Warning).
+				Int64("actual_size_bytes", actualSizeBytes).
+				Str("actual_size_hr", actualSizeHR).
+				Bool("size_max_check_enabled", ths.SizeMax.Set).
+				Str("path", path).
+				Msg(sizeOfFilesTooLargeErr.Error())
+
+			nes.LastError = sizeOfFilesTooLargeErr
+
+			if actualSizeBytes > ths.SizeMax.Critical {
+				stateLabel = nagios.StateCRITICALLabel
+				exitCode = nagios.StateCRITICALExitCode
+			}
+
+			if actualSizeBytes > ths.SizeMax.Warning {
+				stateLabel = nagios.StateWARNINGLabel
+				exitCode = nagios.StateWARNINGExitCode
+			}
+
+			nes.ServiceOutput = fmt.Sprintf(
+				"%s: %s %s",
+				stateLabel,
+				ths.SizeMax.Description,
+				serviceOutputTmpl,
+			)
+
+			nes.ExitStatusCode = exitCode
+
+			return sizeOfFilesTooLargeErr
+
+		case ths.SizeMin.Set &&
+			(actualSizeBytes < ths.SizeMin.Critical || actualSizeBytes < ths.SizeMin.Warning):
+			zlog.Error().Err(sizeOfFilesTooSmallErr).
+				Int64("critical_size_min_bytes", ths.SizeMin.Critical).
+				Int64("warning_size_min_bytes", ths.SizeMin.Warning).
+				Int64("actual_size_bytes", actualSizeBytes).
+				Str("actual_size_hr", actualSizeHR).
+				Bool("size_min_check_enabled", ths.SizeMin.Set).
+				Str("path", path).
+				Msg(sizeOfFilesTooSmallErr.Error())
+
+			nes.LastError = sizeOfFilesTooSmallErr
+
+			if actualSizeBytes < ths.SizeMin.Critical {
+				stateLabel = nagios.StateCRITICALLabel
+				exitCode = nagios.StateCRITICALExitCode
+			}
+
+			if actualSizeBytes < ths.SizeMin.Warning {
+				stateLabel = nagios.StateWARNINGLabel
+				exitCode = nagios.StateWARNINGExitCode
+			}
+
+			nes.ServiceOutput = fmt.Sprintf(
+				"%s: %s %s",
+				stateLabel,
+				ths.SizeMin.Description,
+				serviceOutputTmpl,
+			)
+
+			nes.ExitStatusCode = exitCode
+
+			return sizeOfFilesTooSmallErr
+
+		}
+
+	}
+
+	return nil
+
+}

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -226,3 +226,21 @@ func (c Config) GroupNameCritical() bool {
 func (c Config) GroupNameWarning() bool {
 	return c.Search.GroupNameMissingWarning != nil
 }
+
+// ResolveIDs returns a ResolveIDs type which indicates whether user opted to
+// resolve user and group id values to name values and if so, at which exit
+// state values.
+func (c Config) ResolveIDs() ResolveIDs {
+	return ResolveIDs{
+		IDs: IDs{
+			Username:  c.Username(),
+			GroupName: c.GroupName(),
+		},
+		UsernameCheck:     c.UsernameCritical() || c.UsernameWarning(),
+		UsernameCritical:  c.UsernameCritical(),
+		UsernameWarning:   c.UsernameWarning(),
+		GroupNameCheck:    c.GroupNameCritical() || c.GroupNameWarning(),
+		GroupNameCritical: c.GroupNameCritical(),
+		GroupNameWarning:  c.GroupNameWarning(),
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -29,6 +29,31 @@ type FileSizeThresholds struct {
 	Set         bool
 }
 
+// FileSizeThresholdsMinMax represents the combined minimum and maximum
+// user-specified file size thresholds for specified paths.
+type FileSizeThresholdsMinMax struct {
+	SizeMin FileSizeThresholds
+	SizeMax FileSizeThresholds
+}
+
+// ResolveIDs is a helper struct to record whether user opted to resolve user
+// and group id values to name values and if so, at which exit state values.
+type ResolveIDs struct {
+	UsernameCheck     bool
+	UsernameCritical  bool
+	UsernameWarning   bool
+	GroupNameCheck    bool
+	GroupNameCritical bool
+	GroupNameWarning  bool
+	IDs
+}
+
+// IDs represents username and group name values.
+type IDs struct {
+	Username  string
+	GroupName string
+}
+
 // Search represents options specific to controlling how this application
 // performs searches in the filesystem.
 type Search struct {

--- a/internal/paths/metarecord.go
+++ b/internal/paths/metarecord.go
@@ -128,3 +128,19 @@ func (mr MetaRecords) SortByModTimeDesc() {
 		return mr[i].ModTime().After(mr[j].ModTime())
 	})
 }
+
+// SortBySizeAsc sorts slice of MetaRecord objects in ascending order with
+// smaller values listed first.
+func (mr MetaRecords) SortBySizeAsc() {
+	sort.Slice(mr, func(i, j int) bool {
+		return mr[i].FileInfo.Size() > mr[j].FileInfo.Size()
+	})
+}
+
+// SortBySizeDesc sorts slice of MetaRecord objects in descending order with
+// larger values listed first.
+func (mr MetaRecords) SortBySizeDesc() {
+	sort.Slice(mr, func(i, j int) bool {
+		return mr[i].FileInfo.Size() < mr[j].FileInfo.Size()
+	})
+}


### PR DESCRIPTION
If specified, the fail-fast logic is applied to items as they are
encountered, otherwise a collection of all encountered items is
built and evaluated after.

As part of this work a number of refactoring steps were applied to
reduce the complexity of the main function and isolate specific
check code within applicable functions.

New helper/wrapper types and a getter method were added to make
it easier to pass related collections of values and error
messages extracted out to the paths package to enable code reuse
and potential comparison later.

New methods for sorting collections by size were also added.

fixes GH-33