### PR TITLE
Update build tags for Go 1.17 compatibility

### DIFF
--- a/cmd/ugs/main-unix.go
+++ b/cmd/ugs/main-unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright 2020 Adam Chalkley

--- a/cmd/ugs/main-windows.go
+++ b/cmd/ugs/main-windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright 2020 Adam Chalkley

--- a/internal/config/validate-unix.go
+++ b/internal/config/validate-unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright 2020 Adam Chalkley

--- a/internal/config/validate-windows.go
+++ b/internal/config/validate-windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright 2020 Adam Chalkley

--- a/internal/paths/ids-unix.go
+++ b/internal/paths/ids-unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright 2020 Adam Chalkley

--- a/internal/paths/ids-windows.go
+++ b/internal/paths/ids-windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright 2020 Adam Chalkley


### PR DESCRIPTION
golangci-lint v1.42.1 introduced changes to the `gofmt` linter.
These changes appear to match the same ones introduced with
Go 1.17 which expect build tags to be in a specific format
OR include an additional leading set of build tags with
the `//go:` prefix.

This commit adds this additional build tag entry to both
os-specific variants of the `validate-*.go` file.