### PR TITLE
Fix various atc0005/go-nagios usage linting errors

### DIFF
--- a/cmd/check_path/age.go
+++ b/cmd/check_path/age.go
@@ -52,11 +52,11 @@ func checkAge(path string, ths config.FileAgeThresholds, zlog *zerolog.Logger, n
 				Str("path", path).
 				Msg("old files found")
 
-			nes.LastError = fmt.Errorf(
+			nes.AddError(fmt.Errorf(
 				"%d files & directories evaluated: %w",
 				len(metaRecords),
 				paths.ErrPathOldFilesFound,
-			)
+			))
 
 			fileAge := time.Since(record.ModTime()).Hours() / 24
 

--- a/cmd/check_path/exists.go
+++ b/cmd/check_path/exists.go
@@ -25,7 +25,7 @@ func checkExists(list []string, critical bool, warning bool, zlog *zerolog.Logge
 	// error: path found
 	case errors.Is(err, paths.ErrPathExists):
 
-		nes.LastError = err
+		nes.AddError(err)
 		nes.LongServiceOutput += fmt.Sprintf(
 			"* Path %q%s** Last Modified: %v%s",
 			pathInfo.FQPath,
@@ -57,7 +57,7 @@ func checkExists(list []string, critical bool, warning bool, zlog *zerolog.Logge
 	// error: other
 	case err != nil:
 		zlog.Err(err).Msg("Error checking path")
-		nes.LastError = err
+		nes.AddError(err)
 		nes.ServiceOutput = fmt.Sprintf(
 			"%s: Error checking path: %v",
 			nagios.StateCRITICALLabel,
@@ -70,7 +70,6 @@ func checkExists(list []string, critical bool, warning bool, zlog *zerolog.Logge
 	// OK: desired state; paths not found
 	case err == nil:
 
-		nes.LastError = nil
 		nes.ServiceOutput = fmt.Sprintf(
 			"%s: Specified (unwanted) paths do not exist",
 			nagios.StateOKLabel,

--- a/cmd/check_path/ids.go
+++ b/cmd/check_path/ids.go
@@ -43,7 +43,7 @@ func checkIDs(path string, resolveIDs config.ResolveIDs, zlog *zerolog.Logger, n
 				Str("path", path).
 				Msg(resolveErr.Error())
 
-			nes.LastError = resolveErr
+			nes.AddError(resolveErr)
 			nes.ServiceOutput = fmt.Sprintf(
 				"%s: failed to resolve IDs: %v [path: %q]",
 				nagios.StateCRITICALLabel,
@@ -70,7 +70,7 @@ func checkIDs(path string, resolveIDs config.ResolveIDs, zlog *zerolog.Logger, n
 				Str("path", path).
 				Msg(statusMsg)
 
-			nes.LastError = paths.ErrPathMissingUsername
+			nes.AddError(paths.ErrPathMissingUsername)
 
 			switch {
 			case resolveIDs.UsernameCritical:
@@ -111,7 +111,7 @@ func checkIDs(path string, resolveIDs config.ResolveIDs, zlog *zerolog.Logger, n
 				Str("path", path).
 				Msg(statusMsg)
 
-			nes.LastError = paths.ErrPathMissingGroupName
+			nes.AddError(paths.ErrPathMissingGroupName)
 
 			switch {
 			case resolveIDs.GroupNameCritical:

--- a/cmd/check_path/main.go
+++ b/cmd/check_path/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	cfg, configErr := config.New()
 	if configErr != nil {
-		nagiosExitState.LastError = configErr
+		nagiosExitState.AddError(configErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 		log.Err(configErr).Msg("Error validating configuration")
 
@@ -147,7 +147,7 @@ func main() {
 					Str("path", path).
 					Msg("error processing path")
 
-				nagiosExitState.LastError = result.Error
+				nagiosExitState.AddError(result.Error)
 				nagiosExitState.ServiceOutput = fmt.Sprintf(
 					"%s: Error processing path: %s",
 					nagios.StateCRITICALLabel,
@@ -276,7 +276,6 @@ func main() {
 		Bool("size_max_check_enabled", cfg.SizeMax().Set).
 		Msg(statusMsg)
 
-	nagiosExitState.LastError = nil
 	nagiosExitState.ServiceOutput = fmt.Sprintf(
 		"%s: %s",
 		nagios.StateOKLabel,

--- a/cmd/check_path/size.go
+++ b/cmd/check_path/size.go
@@ -89,7 +89,7 @@ func checkSize(path string, ths config.FileSizeThresholdsMinMax, zlog *zerolog.L
 				Str("path", path).
 				Msg(sizeOfFilesTooLargeErr.Error())
 
-			nes.LastError = sizeOfFilesTooLargeErr
+			nes.AddError(sizeOfFilesTooLargeErr)
 
 			// prevent fall-through logic (GH-40)
 			switch {
@@ -124,7 +124,7 @@ func checkSize(path string, ths config.FileSizeThresholdsMinMax, zlog *zerolog.L
 				Str("path", path).
 				Msg(sizeOfFilesTooSmallErr.Error())
 
-			nes.LastError = sizeOfFilesTooSmallErr
+			nes.AddError(sizeOfFilesTooSmallErr)
 
 			// prevent fall-through logic (GH-40)
 			switch {


### PR DESCRIPTION
Replace direct usage of `ExitState.LastError` field with `AddError()` method calls.

refs GH-128