### PR TITLE
Add missing cmd doc file

### DIFF
--- a/cmd/check_path/doc.go
+++ b/cmd/check_path/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Nagios plugin that may be used to verify the ownership, group, permissions,
+// age or size of specific files or directories.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-path
+package main

--- a/cmd/dirtest/doc.go
+++ b/cmd/dirtest/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Prototype binary.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-path
+package main

--- a/cmd/perms/doc.go
+++ b/cmd/perms/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Prototype binary.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-path
+package main

--- a/cmd/ugs/doc.go
+++ b/cmd/ugs/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Adam Chalkley
+//
+// https://github.com/atc0005/check-path
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+// Prototype binary.
+//
+// See our [GitHub repo]:
+//
+//   - to review documentation (including examples)
+//   - for the latest code
+//   - to file an issue or submit improvements for review and potential
+//     inclusion into the project
+//
+// [GitHub repo]: https://github.com/atc0005/check-path
+package main


### PR DESCRIPTION
Add "package" doc file to resolve revive `package-comment` linting error surfaced by recent linter update.