### PR TITLE
Update project to Go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,5 +81,5 @@ updates:
         versions:
           # Ignore updates from series associated with the latest "stable"
           # Go release and no longer supported Go versions.
-          - ">= 1.18"
-          - "< 1.17"
+          - ">= 1.20"
+          - "< 1.19"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -15,4 +15,4 @@
 # binaries) to reflect that version of Go.
 
 # https://hub.docker.com/_/golang
-FROM golang:1.17.13
+FROM golang:1.19.0

--- a/doc.go
+++ b/doc.go
@@ -6,44 +6,36 @@
 // full license information.
 
 /*
-
 This repo provides a Nagios plugin used to verify the ownership, group,
 permissions, age or size of specific files or directories.
 
-PROJECT HOME
+# Project Home
 
 See our GitHub repo (https://github.com/atc0005/check-path) for the latest
 code, to file an issue or submit improvements for review and potential
 inclusion into the project.
 
-PURPOSE
+# Purpose
 
 Verify the ownership, group, age, permissions (GH-6), size or existence of
 specific files or directories.
 
-FEATURES
+# Features
 
-• Age checks: CRITICAL and WARNING thresholds
+  - Age checks: CRITICAL and WARNING thresholds
+  - Size checks: minimum and maximum CRITICAL and WARNING thresholds
+  - Existence checks: CRITICAL or WARNING (as specified) if present
+  - Username checks: CRITICAL or WARNING (as specified) if missing
+  - Group Name checks: CRITICAL or WARNING (as specified) if missing
+  - Optional directory recursion
+  - Optional "missing OK" toggle, compatible with most checks
+  - Optional exclusion of specific paths from evaluation
+  - Optional "fail fast" behavior in an effort to avoid I/O churn over deep
+    paths. See "Known issues" section of README for potential issues with this
+    option.
 
-• Size checks: minimum and maximum CRITICAL and WARNING thresholds
-
-• Existence checks: CRITICAL or WARNING (as specified) if present
-
-• Username checks: CRITICAL or WARNING (as specified) if missing
-
-• Group Name checks: CRITICAL or WARNING (as specified) if missing
-
-• Optional directory recursion
-
-• Optional "missing OK" toggle, compatible with most checks
-
-• Optional exclusion of specific paths from evaluation
-
-• Optional "fail fast" behavior in an effort to avoid I/O churn over deep paths. See "Known issues" section of README for potential issues with this option.
-
-USAGE
+# Usage
 
 See our main README for supported settings and examples.
-
 */
 package main

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@
 
 module github.com/atc0005/check-path
 
-go 1.17
+go 1.19
 
 require (
 	github.com/alexflint/go-arg v1.4.3


### PR DESCRIPTION
- update go.mod file from Go 1.17 to 1.19
- update doc.go file to use Go 1.19 package doc comments syntax
- update "Canary" Dockerfile to reflect current Go 1.19 version
- update Dependabot configuration for Dockerfile to ignore Go
  releases outside of the Go 1.19 release series