### PR TITLE
Use UNKNOWN state for invalid command-line args

### DIFF
--- a/cmd/check_path/main.go
+++ b/cmd/check_path/main.go
@@ -30,12 +30,12 @@ func main() {
 	cfg, configErr := config.New()
 	if configErr != nil {
 		plugin.AddError(configErr)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 		log.Err(configErr).Msg("Error validating configuration")
 
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Failed to load configuration: %v",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 			configErr,
 		)
 


### PR DESCRIPTION
Update handling of invalid flags/values to use an UNKNOWN exit state to comply with Nagios Plugin Guideline
recommendations.

fixes GH-171
refs atc0005/todo#55
refs https://nagios-plugins.org/doc/guidelines.html