### PR TITLE
Refactor project build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-# Copyright 2020 Adam Chalkley
+# Copyright 2023 Adam Chalkley
 #
 # https://github.com/atc0005/check-path
 #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,3 +83,22 @@ updates:
           # Go release and no longer supported Go versions.
           - ">= 1.20"
           - "< 1.19"
+
+  # Monitor image used to build dev & stable project releases
+  - package-ecosystem: docker
+    directory: "/dependabot/docker/builds"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "builds"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "docker"

--- a/Makefile
+++ b/Makefile
@@ -19,24 +19,80 @@
 # https://gist.github.com/subfuzion/0bd969d08fe0d8b5cc4b23c795854a13
 # https://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
 # https://stackoverflow.com/questions/38801796/makefile-set-if-variable-is-empty
+# https://stackoverflow.com/questions/1909188/define-make-variable-at-rule-execution-time
 
-SHELL = /bin/bash
+SHELL := /bin/bash
 
 # Space-separated list of cmd/BINARY_NAME directories to build
-WHAT 					= check_path
+WHAT 					:= check_path
 
-# TODO: This will need to be standardized across all cmd files in order to
-# work as intended.
-#
+PROJECT_NAME			:= check-path
+
 # What package holds the "version" variable used in branding/version output?
 # VERSION_VAR_PKG			= $(shell go list -m)
-VERSION_VAR_PKG			= $(shell go list -m)/internal/config
+VERSION_VAR_PKG			:= $(shell go list -m)/internal/config
 # VERSION_VAR_PKG			= main
 
-OUTPUTDIR 				= release_assets
+OUTPUTDIR 				:= release_assets
+
+ASSETS_PATH				:= $(CURDIR)/$(OUTPUTDIR)
+
+PROJECT_DIR				:= $(CURDIR)
 
 # https://gist.github.com/TheHippo/7e4d9ec4b7ed4c0d7a39839e6800cc16
-VERSION 				= $(shell git describe --always --long --dirty)
+# VERSION 				:= $(shell git describe --always --long --dirty)
+
+# Use https://github.com/choffmeister/git-describe-semver to generate
+# semantic version compatible tag values for use as image suffix.
+#
+# Attempt to use environment variable. This is set within GitHub Actions
+# Workflows, but not via local Makefile use. If environment variable is not
+# set, attempt to use local installation of choffmeister/git-describe-semver
+# tool.
+#
+# The build image used by this project for release builds includes this tool,
+# so we are covered there.
+#
+# If this tool is not already installed locally and someone runs this Makefile
+# we use a "YOU_NEED_TO_*" placeholder string as a breadcrumb indicating what
+# needs to be done to resolve the issue.
+#
+# This is a VERY expensive operation as it is expanded on every use (due to
+# the ?= assignment operator)
+# REPO_VERSION              ?= $(shell git-describe-semver --fallback 'v0.0.0' 2>/dev/null || echo YOU_NEED_TO_RUN_depsinstall_makefile_recipe)
+#
+ifeq ($(origin REPO_VERSION), undefined)
+# This is an expensive operation on systems where tools like Cisco AMP are
+# present/active.
+REPO_VERSION 				:= $(shell git-describe-semver --fallback 'v0.0.0' 2>/dev/null || echo YOU_NEED_TO_RUN_depsinstall_makefile_recipe)
+
+# https://make.mad-scientist.net/deferred-simple-variable-expansion/
+# https://stackoverflow.com/questions/50771834/how-to-get-at-most-once-semantics-in-variable-assignments
+# REPO_VERSION = $(eval REPO_VERSION := $$(shell git-describe-semver --fallback 'v0.0.0' 2>/dev/null || echo YOU_NEED_TO_RUN_depsinstall_makefile_recipe))$(REPO_VERSION)
+
+endif
+
+DEB_X64_STABLE_PKG_FILE	:= $(PROJECT_NAME)-$(REPO_VERSION)_amd64.deb
+RPM_X64_STABLE_PKG_FILE	:= $(PROJECT_NAME)-$(REPO_VERSION).x86_64.rpm
+
+DEB_X64_DEV_PKG_FILE	:= $(PROJECT_NAME)-dev-$(REPO_VERSION)_amd64.deb
+RPM_X64_DEV_PKG_FILE	:= $(PROJECT_NAME)-dev-$(REPO_VERSION).x86_64.rpm
+
+# Used when generating download URLs when building assets for public release.
+# If the current commit doesn't match an existing tag an error is emitted. We
+# toss that error and use a placeholder value.
+RELEASE_TAG 			:= $(shell git describe --exact-match --tags 2>/dev/null || echo PLACEHOLDER)
+
+# TESTING purposes
+#RELEASE_TAG 			:= 0.11.0
+
+BASE_URL				:= https://github.com/atc0005/$(PROJECT_NAME)/releases/download
+
+ALL_DOWNLOAD_LINKS_FILE	:= $(ASSETS_PATH)/$(PROJECT_NAME)-$(RELEASE_TAG)-all-links.txt
+PKG_DOWNLOAD_LINKS_FILE	:= $(ASSETS_PATH)/$(PROJECT_NAME)-$(RELEASE_TAG)-pkgs-links.txt
+
+# Exported so that nFPM can reference it when generating packages.
+export SEMVER  := $(REPO_VERSION)
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
@@ -57,6 +113,11 @@ VERSION 				= $(shell git describe --always --long --dirty)
 #	Use pure Go implementation of user and group id/name resolution.
 #	Use pure Go implementation of DNS resolver.
 #
+# -trimpath
+#	https://golang.org/cmd/go/
+#   removes all file system paths from the compiled executable, to improve
+#   build reproducibility.
+#
 # -extldflags '-static'
 #	Pass 'static' flag to external linker.
 #
@@ -74,10 +135,12 @@ VERSION 				= $(shell git describe --always --long --dirty)
 #	https://golang.org/cmd/cgo/
 #	explicitly disable use of cgo
 #	removes potential need for linkage against local c library (e.g., glibc)
-BUILDCMD				=	CGO_ENABLED=0 go build -mod=vendor -trimpath -a -ldflags "-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
-GOCLEANCMD				=	go clean -mod=vendor ./...
-GITCLEANCMD				= 	git clean -xfd
-CHECKSUMCMD				=	sha256sum -b
+BUILDCMD				:=	CGO_ENABLED=0 go build -mod=vendor -trimpath -a -ldflags "-s -w -X $(VERSION_VAR_PKG).version=$(REPO_VERSION)"
+QUICK_BUILDCMD			:=	go build -mod=vendor
+GOCLEANCMD				:=	go clean -mod=vendor ./...
+GITCLEANCMD				:= 	git clean -xfd
+CHECKSUMCMD				:=	sha256sum -b
+COMPRESSCMD				:= xz --compress --threads=0 --stdout
 
 .DEFAULT_GOAL := help
 
@@ -142,13 +205,35 @@ goclean:
 	@echo "Removing object files and cached files ..."
 	@$(GOCLEANCMD)
 	@echo "Removing any existing release assets"
-	@mkdir -p "$(OUTPUTDIR)"
-	@rm -vf $(wildcard ${OUTPUTDIR}/*/*-linux-*)
-	@rm -vf $(wildcard ${OUTPUTDIR}/*/*-windows-*)
+	@mkdir -p "$(ASSETS_PATH)"
+	@rm -vf $(wildcard $(ASSETS_PATH)/*/*-linux-*)
+	@rm -vf $(wildcard $(ASSETS_PATH)/*/*-windows-*)
+	@rm -vf $(wildcard $(ASSETS_PATH)/packages/*/*.rpm)
+	@rm -vf $(wildcard $(ASSETS_PATH)/packages/*/*.rpm.sha256)
+	@rm -vf $(wildcard $(ASSETS_PATH)/packages/*/*.deb)
+	@rm -vf $(wildcard $(ASSETS_PATH)/packages/*/*.deb.sha256)
+	@rm -vf $(wildcard $(ASSETS_PATH)/*-links.txt)
+	@rm -vf $(wildcard $(PROJECT_DIR)/cmd/*/*.syso)
+
+	@echo "Removing any existing quick build release assets"
+	@for target in $(WHAT); do \
+		rm -vf $(ASSETS_PATH)/$${target}/$${target}; \
+	done
+
+	@echo "Removing any empty asset build paths"
+	@find ${ASSETS_PATH} -mindepth 1 -type d -empty -delete
 
 .PHONY: clean
 ## clean: alias for goclean
 clean: goclean
+
+.PHONY: clean-linux-x64-dev
+## clean-linux-x64-dev: removes dev assets for Linux x64 distros
+clean-linux-x64-dev:
+	@echo "Removing dev build assets used to generate dev packages"
+	@for target in $(WHAT); do \
+		rm -vf $(ASSETS_PATH)/$${target}/$$target-linux-amd64-dev; \
+	done
 
 .PHONY: gitclean
 ## gitclean: WARNING - recursively cleans working tree by removing non-versioned files
@@ -160,48 +245,679 @@ gitclean:
 ## pristine: run goclean and gitclean to remove local changes
 pristine: goclean gitclean
 
+.PHONY: depsinstall
+## depsinstall: install or update common build dependencies
+depsinstall:
+	@echo "Installing current version of build dependencies"
+
+	@export PATH="${PATH}:$(go env GOPATH)/bin"
+
+	@echo "Installing latest go-winres version ..."
+	go install github.com/tc-hib/go-winres@latest
+
+	@echo "Installing latest nFPM version ..."
+	go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+	nfpm --version
+
+	@echo "Installing latest git-describe-semver version ..."
+	go install github.com/choffmeister/git-describe-semver@latest
+
+	@echo "Finished installing or updating build dependencies"
+
 .PHONY: all
 # https://stackoverflow.com/questions/3267145/makefile-execute-another-target
 ## all: generates assets for Linux distros and Windows
 all: clean windows linux
 	@echo "Completed all cross-platform builds ..."
 
-.PHONY: windows
-## windows: generates assets for Windows systems
-windows:
-	@echo "Building release assets for windows ..."
+.PHONY: quick
+## quick: generates non-release binaries for current platform, arch
+quick:
+	@echo "Building non-release assets for current platform, arch ..."
 
-	@for target in $(WHAT); do \
-		mkdir -p $(OUTPUTDIR)/$$target && \
-		echo "Building $$target 386 binaries" && \
-		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-windows-386.exe ${PWD}/cmd/$$target && \
-		echo "Building $$target amd64 binaries" && \
-		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-windows-amd64.exe ${PWD}/cmd/$$target && \
-		echo "Generating $$target checksum files" && \
-		cd $(OUTPUTDIR)/$$target && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-windows-386.exe > $$target-$(VERSION)-windows-386.exe.sha256 && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-windows-amd64.exe > $$target-$(VERSION)-windows-amd64.exe.sha256 && \
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$${target} && \
+		echo "  building $${target} binary" && \
+		$(QUICK_BUILDCMD) -o $(ASSETS_PATH)/$${target}/$${target} $(PROJECT_DIR)/cmd/$${target}; \
+	done
+
+	@echo "Completed tasks for quick build"
+
+.PHONY: windows-x86-build
+## windows-x86-build: builds assets for Windows x86 systems
+windows-x86-build:
+	@echo "Building release assets for windows x86 ..."
+
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  running go generate for $$target 386 binary ..." && \
+		cd $(PROJECT_DIR)/cmd/$$target && \
+		env GOOS=windows GOARCH=386 go generate && \
+		cd $(PROJECT_DIR) && \
+		echo "  building $$target 386 binary" && \
+		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-windows-386.exe $(PROJECT_DIR)/cmd/$$target; \
+	done
+
+	@echo "Completed build tasks for windows x86"
+
+.PHONY: windows-x86-compress
+## windows-x86-compress: compresses generated Windows x86 assets
+windows-x86-compress:
+	@echo "Compressing release assets for windows x86 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target 386 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-windows-386.exe > \
+			$(ASSETS_PATH)/$$target/$$target-windows-386.exe.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-windows-386.exe; \
+	done
+
+	@echo "Completed compress tasks for windows x86"
+
+.PHONY: windows-x86-checksums
+## windows-x86-checksums: generates checksum files for Windows x86 assets
+windows-x86-checksums:
+	@echo "Generating checksum files for windows x86 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-windows-386.exe.xz > $$target-windows-386.exe.xz.sha256 && \
 		cd $$OLDPWD; \
 	done
 
-	@echo "Completed build tasks for windows"
+	@echo "Completed generation of checksum files for windows x86"
+
+.PHONY: windows-x86-links
+## windows-x86-links: generates download URLs for Windows x86 assets
+windows-x86-links:
+	@echo "Generating download links for windows x86 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-386.exe.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-386.exe.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+	done
+
+	@echo "Completed generating download links for windows x86 assets"
+
+.PHONY: windows-x64-build
+## windows-x64-build: builds assets for Windows x64 systems
+windows-x64-build:
+	@echo "Building release assets for windows x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  running go generate for $$target amd64 binary ..." && \
+		cd $(PROJECT_DIR)/cmd/$$target && \
+		env GOOS=windows GOARCH=amd64 go generate && \
+		cd $(PROJECT_DIR) && \
+		echo "  building $$target amd64 binary" && \
+		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-windows-amd64.exe $(PROJECT_DIR)/cmd/$$target; \
+	done
+
+	@echo "Completed build tasks for windows x64"
+
+.PHONY: windows-x64-compress
+## windows-x64-compress: compresses generated Windows x64 assets
+windows-x64-compress:
+	@echo "Compressing release assets for windows x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target amd64 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-windows-amd64.exe > \
+			$(ASSETS_PATH)/$$target/$$target-windows-amd64.exe.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-windows-amd64.exe; \
+	done
+
+	@echo "Completed compress tasks for windows x64"
+
+.PHONY: windows-x64-checksums
+## windows-x64-checksums: generates checksum files for Windows x64 assets
+windows-x64-checksums:
+	@echo "Generating checksum files for windows x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-windows-amd64.exe.xz > $$target-windows-amd64.exe.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed generation of checksum files for windows x64"
+
+.PHONY: windows-x64-links
+## windows-x64-links: generates download URLs for Windows x64 assets
+windows-x64-links:
+	@echo "Generating download links for windows x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-amd64.exe.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-amd64.exe.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+	done
+
+	@echo "Completed generating download links for windows x64 assets"
+
+.PHONY: windows-x86
+## windows-x86: generates assets for Windows x86
+windows-x86: windows-x86-build windows-x86-compress windows-x86-checksums
+	@echo "Completed all tasks for windows x86"
+
+.PHONY: windows-x64
+## windows-x64: generates assets for Windows x64
+windows-x64: windows-x64-build windows-x64-compress windows-x64-checksums
+	@echo "Completed all tasks for windows x64"
+
+.PHONY: windows
+## windows: generates assets for Windows x86 and x64 systems
+windows: windows-x86 windows-x64
+	@echo "Completed all tasks for windows"
+
+.PHONY: windows-links
+## windows-links: generates download URLs for Windows x86 and x64 assets
+windows-links: windows-x86-links windows-x64-links
+	@echo "Completed generating download links for windows x86 and x64 assets"
+
+.PHONY: linux-x86-build
+## linux-x86-build: builds assets for Linux x86 distros
+linux-x86-build:
+	@echo "Building release assets for linux x86 ..."
+
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  building $$target 386 binary" && \
+		env GOOS=linux GOARCH=386 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-linux-386 $(PROJECT_DIR)/cmd/$$target; \
+	done
+
+	@echo "Completed build tasks for linux x86"
+
+.PHONY: linux-x86-compress
+## linux-x86-compress: compresses generated Linux x86 assets
+linux-x86-compress:
+	@echo "Compressing release assets for linux x86 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target 386 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-386 > \
+			$(ASSETS_PATH)/$$target/$$target-linux-386.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-linux-386; \
+	done
+
+	@echo "Completed compress tasks for linux x86"
+
+.PHONY: linux-x86-checksums
+## linux-x86-checksums: generates checksum files for Linux x86 assets
+linux-x86-checksums:
+	@echo "Generating checksum files for linux x86 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-linux-386.xz > $$target-linux-386.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed generation of checksum files for linux x86"
+
+.PHONY: linux-x86-links
+## linux-x86-links: generates download URLs for Linux x86 assets
+linux-x86-links:
+	@echo "Generating download links for linux x86 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-386.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-386.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+	done
+
+	@echo "Completed generating download links for linux x86 assets"
+
+.PHONY: linux-x64-build
+## linux-x64-build: builds assets for Linux x64 distros
+linux-x64-build:
+	@echo "Building release assets for linux x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  building $$target amd64 binary" && \
+		env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-linux-amd64 $(PROJECT_DIR)/cmd/$$target; \
+	done
+
+	@echo "Completed build tasks for linux x64"
+
+.PHONY: linux-x64-compress
+## linux-x64-compress: compresses generated Linux x64 assets
+linux-x64-compress:
+	@echo "Compressing release assets for linux x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target amd64 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-amd64 > \
+			$(ASSETS_PATH)/$$target/$$target-linux-amd64.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-linux-amd64; \
+	done
+
+	@echo "Completed compress tasks for linux x64"
+
+.PHONY: linux-x64-checksums
+## linux-x64-checksums: generates checksum files for Linux x64 assets
+linux-x64-checksums:
+	@echo "Generating checksum files for linux x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-linux-amd64.xz > $$target-linux-amd64.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+.PHONY: linux-x64-links
+## linux-x64-links: generates download URLs for Linux x64 assets
+linux-x64-links:
+	@echo "Generating download links for linux x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  Generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-amd64.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-amd64.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+	done
+
+	@echo "Completed generating download links for linux x64 assets"
+
+.PHONY: linux-x64-dev-build
+## linux-x64-dev-build: builds dev assets for Linux x64 distros
+linux-x64-dev-build:
+	@echo "Building dev assets for linux x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  building $$target amd64 binary" && \
+		env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-linux-amd64-dev $(PROJECT_DIR)/cmd/$$target; \
+	done
+
+	@echo "Completed dev build tasks for linux x64"
+
+.PHONY: linux-x64-dev-compress
+## linux-x64-dev-compress: compresses generated dev Linux x64 assets
+linux-x64-dev-compress:
+	@echo "Compressing dev assets for linux x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target amd64 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-amd64-dev > \
+			$(ASSETS_PATH)/$$target/$$target-linux-amd64-dev.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-linux-amd64-dev; \
+	done
+
+	@echo "Completed dev compress tasks for linux x64"
+
+.PHONY: linux-x64-dev-checksums
+## linux-x64-dev-checksums: generates checksum files for dev Linux x64 assets
+linux-x64-dev-checksums:
+	@echo "Generating checksum files for dev linux x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-linux-amd64-dev.xz > $$target-linux-amd64-dev.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+.PHONY: linux-x64-dev-links
+## linux-x64-dev-links: generates download URLs for dev Linux x64 assets
+linux-x64-dev-links:
+	@echo "Generating download links for dev linux x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  Generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-amd64-dev.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-amd64-dev.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+	done
+
+	@echo "Completed generating download links for dev linux x64 assets"
+
+.PHONY: linux-x86
+## linux-x86: generates assets for Linux x86
+linux-x86: linux-x86-build linux-x86-compress linux-x86-checksums
+	@echo "Completed all tasks for linux x86"
+
+.PHONY: linux-x64
+## linux-x64: generates assets for Linux x64
+linux-x64: linux-x64-build linux-x64-compress linux-x64-checksums
+	@echo "Completed all tasks for linux x64"
 
 .PHONY: linux
-## linux: generates assets for Linux distros
-linux:
-	@echo "Building release assets for linux ..."
+## linux: generates assets for Linux x86 and x64 distros
+linux: linux-x86 linux-x64
+	@echo "Completed all tasks for linux"
 
-	@for target in $(WHAT); do \
-		mkdir -p $(OUTPUTDIR)/$$target && \
-		echo "Building $$target 386 binaries" && \
-		env GOOS=linux GOARCH=386 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-linux-386 ${PWD}/cmd/$$target && \
-		echo "Building $$target amd64 binaries" && \
-		env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(OUTPUTDIR)/$$target/$$target-$(VERSION)-linux-amd64 ${PWD}/cmd/$$target && \
-		echo "Generating $$target checksum files" && \
-		cd $(OUTPUTDIR)/$$target && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-linux-386 > $$target-$(VERSION)-linux-386.sha256 && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-linux-amd64 > $$target-$(VERSION)-linux-amd64.sha256 && \
-		cd $$OLDPWD; \
-	done
+.PHONY: linux-links
+## linux-links: generates download URLs for Linux x86 and x64 assets
+linux-links: linux-x86-links linux-x64-links
+	@echo "Completed generating download links for linux x86 and x64 assets"
 
-	@echo "Completed build tasks for linux"
+.PHONY: packages-stable
+## packages-stable: generates "stable" release series DEB and RPM packages
+packages-stable: linux-x64-build
+
+	@echo
+	@echo Generating stable release series packages ...
+
+	@mkdir -p $(ASSETS_PATH)/packages/stable
+
+	@echo
+	@echo "  - stable DEB package ..."
+	@cd $(PROJECT_DIR)/packages/stable && \
+		nfpm package --config nfpm.yaml --packager deb --target $(ASSETS_PATH)/packages/stable/$(DEB_X64_STABLE_PKG_FILE)
+
+	@echo
+	@echo "  - stable RPM package ..."
+	@cd $(PROJECT_DIR)/packages/stable && \
+		nfpm package --config nfpm.yaml --packager rpm --target $(ASSETS_PATH)/packages/stable/$(RPM_X64_STABLE_PKG_FILE)
+
+	@echo
+	@echo "Generating checksum files ..."
+
+	@echo "  - stable DEB package checksum file"
+	@set -e ;\
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.deb" -printf '%P\n'); do \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
+
+	@echo "  - stable RPM package checksum file"
+	@set -e ;\
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.rpm" -printf '%P\n'); do \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
+
+	@echo
+	@echo "Completed package build tasks"
+
+.PHONY: packages-dev
+## packages-dev: generates "dev" release series DEB and RPM packages
+packages-dev: linux-x64-dev-build
+
+	@echo
+	@echo Generating dev release series packages ...
+
+	@mkdir -p $(ASSETS_PATH)/packages/dev
+
+	@echo
+	@echo "  - dev DEB package ..."
+	@cd $(PROJECT_DIR)/packages/dev && \
+		nfpm package --config nfpm.yaml --packager deb --target $(ASSETS_PATH)/packages/dev/$(DEB_X64_DEV_PKG_FILE)
+
+	@echo
+	@echo "  - dev RPM package ..."
+	@cd $(PROJECT_DIR)/packages/dev && \
+		nfpm package --config nfpm.yaml --packager rpm --target $(ASSETS_PATH)/packages/dev/$(RPM_X64_DEV_PKG_FILE)
+
+	@echo
+	@echo "Generating checksum files ..."
+
+	@echo "  - dev DEB package checksum file"
+	@set -e ;\
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.deb" -printf '%P\n'); do \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
+
+	@echo "  - dev RPM package checksum file"
+	@set -e ;\
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.rpm" -printf '%P\n'); do \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
+
+	@echo
+	@echo "Completed dev release package build tasks"
+
+.PHONY: packages
+## packages: generates "dev" and "stable" release series DEB and RPM packages
+packages: packages-dev packages-stable
+	@echo "Completed all package build tasks"
+
+.PHONY: package-links
+## package-links: generates download URLs for package assets
+package-links:
+
+	@echo "Generating download links for package assets ..."
+
+	@echo "  - DEB package download links"
+	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.deb" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.deb.sha256" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.deb" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.deb.sha256" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@echo "  - RPM package download links"
+	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.rpm" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.rpm.sha256" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.rpm" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.rpm.sha256" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@echo "Completed generating download links for package assets"
+
+.PHONY: links
+## links: generates download URLs for release assets
+links: windows-x86-links windows-x64-links linux-x86-links linux-x64-links package-links
+	@echo "Completed generating download links for all release assets"
+
+.PHONY: dev-build
+## dev-build: generates dev build assets for public release
+dev-build: clean linux-x64-dev-build packages-dev package-links linux-x64-dev-compress linux-x64-dev-checksums linux-x64-dev-links
+	@echo "Completed all tasks for dev release build"
+
+.PHONY: release-build
+## release-build: generates stable build assets for public release
+release-build: clean windows linux-x86 packages-dev clean-linux-x64-dev packages-stable linux-x64-compress linux-x64-checksums links
+	@echo "Completed all tasks for stable release build"
+
+.PHONY: helper-builder-setup
+helper-builder-setup:
+
+	@echo "Beginning regeneration of builder image using $(CONTAINER_COMMAND)"
+	@echo "Removing any previous build image"
+	$(CONTAINER_COMMAND) image prune --all --force --filter "label=atc0005_projects_builder_image"
+
+	@echo "Gathering $(CONTAINER_COMMAND) build environment details"
+	@$(CONTAINER_COMMAND) version
+
+	@echo
+	@echo "Generating release builder image"
+	$(CONTAINER_COMMAND) image build \
+		--pull \
+		--no-cache \
+		--force-rm \
+		. \
+		-f dependabot/docker/builds/Dockerfile \
+		-t builder_image \
+		--label="atc0005_projects_builder_image"
+	@echo "Completed generation of release builder image"
+
+	@echo "Listing current container images managed by $(CONTAINER_COMMAND)"
+	$(CONTAINER_COMMAND) image ls
+
+	@echo
+	@echo "Inspecting release builder image environment using $(CONTAINER_COMMAND)"
+	@$(CONTAINER_COMMAND) inspect --format "{{range .Config.Env}}{{println .}}{{end}}" builder_image
+
+	@echo "Completed regeneration of builder image using $(CONTAINER_COMMAND)"
+
+	@echo "Prepare output path for generated assets"
+	@mkdir -p $(ASSETS_PATH)
+
+.PHONY: docker-release-build
+## docker-release-build: generates stable build assets for public release using docker container
+docker-release-build: CONTAINER_COMMAND := docker
+docker-release-build: clean helper-builder-setup
+
+	@echo "Beginning release build using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate project release assets"
+	$(CONTAINER_COMMAND) container run \
+		--user builduser:builduser \
+		--rm \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make release-build
+
+	@echo "Completed release build using $(CONTAINER_COMMAND)"
+
+.PHONY: podman-release-build
+## podman-release-build: generates stable build assets for public release using podman container
+podman-release-build: CONTAINER_COMMAND := podman
+podman-release-build: clean helper-builder-setup
+
+	@echo "Beginning release build using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate project release assets"
+	$(CONTAINER_COMMAND) container run \
+		--rm \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make release-build
+
+	@echo "Completed release build using $(CONTAINER_COMMAND)"
+
+.PHONY: docker-dev-build
+## docker-dev-build: generates dev build assets for public release using docker container
+docker-dev-build: CONTAINER_COMMAND := docker
+docker-dev-build: clean helper-builder-setup
+
+	@echo "Beginning dev build using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate project release assets"
+	$(CONTAINER_COMMAND) container run \
+		--user builduser:builduser \
+		--rm \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make dev-build
+
+	@echo "Completed dev build using $(CONTAINER_COMMAND)"
+
+.PHONY: podman-dev-build
+## podman-dev-build: generates dev build assets for public release using podman container
+podman-dev-build: CONTAINER_COMMAND := podman
+podman-dev-build: clean helper-builder-setup
+
+	@echo "Beginning dev build using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate project release assets"
+	$(CONTAINER_COMMAND) container run \
+		--rm \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make dev-build
+
+	@echo "Completed dev build using $(CONTAINER_COMMAND)"
+
+.PHONY: docker-packages
+## docker-packages: generates dev and stable packages using builder image
+docker-packages: CONTAINER_COMMAND := docker
+docker-packages: helper-builder-setup
+
+	@echo "Beginning package generation using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate packages"
+
+	@echo "Building with $(CONTAINER_COMMAND)"
+	$(CONTAINER_COMMAND) container run \
+		--rm \
+		--user builduser:builduser \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make packages
+
+	@echo "Completed package generation using $(CONTAINER_COMMAND)"
+
+.PHONY: podman-packages
+## podman-packages: generates dev and stable packages using podman container
+podman-packages: CONTAINER_COMMAND := podman
+podman-packages: helper-builder-setup
+
+	@echo "Beginning package generation using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate packages"
+
+	@echo "Building with $(CONTAINER_COMMAND)"
+	$(CONTAINER_COMMAND) container run \
+		--rm \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make packages
+
+	@echo "Completed package generation using $(CONTAINER_COMMAND)"

--- a/README.md
+++ b/README.md
@@ -252,13 +252,24 @@ been tested.
    - if using `go build`
      - look in `/tmp/check-path/`
 
+**NOTE**: Depending on which `Makefile` recipe you use the generated binary
+may be compressed and have an `xz` extension. If so, you should decompress the
+binary first before deploying it (e.g., `xz -d check_path-linux-amd64.xz`).
+
 ### Using release binaries
 
 1. Download the [latest
    release](https://github.com/atc0005/check-path/releases/latest) binaries
+1. Decompress binaries
+   - e.g., `xz -d check_path-linux-amd64.xz`
 1. Deploy
    - Place `check_path` alongside your other Nagios plugins
      - e.g., `/usr/lib/nagios/plugins/` or `/usr/lib64/nagios/plugins/`
+
+**NOTE**:
+
+DEB and RPM packages are provided as an alternative to manually deploying
+binaries.
 
 ## Configuration
 

--- a/cmd/check_path/main.go
+++ b/cmd/check_path/main.go
@@ -5,6 +5,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root for
 // full license information.
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 package main
 
 import (

--- a/cmd/check_path/winres/winres.json
+++ b/cmd/check_path/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to check/verify filesystem paths.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-path project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to check/verify filesystem paths.",
+            "FileVersion": "",
+            "InternalName": "check_path",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-path",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/dependabot/docker/builds/Dockerfile
+++ b/dependabot/docker/builds/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+
+# Purpose:
+#
+# Dependabot-maintained Dockerfile used by Makefile-driven release builds.
+#
+
+# https://github.com/atc0005/go-ci/releases
+# https://github.com/atc0005/go-ci/pkgs/container/go-ci
+FROM ghcr.io/atc0005/go-ci:go-ci-oldstable-build-v0.10.4
+
+# Setup isolated build environment with a full copy of the Git repo contents
+# MINUS any file or path listed in the .dockerignore file at the root of this
+# repo.
+RUN useradd --create-home --shell /bin/bash --user-group builduser
+
+# Prevent Git from complaining when it encounters Git-tracked directories that
+# are owned by someone other than the current user. We set this at the
+# "system" level so that the setting is not specific to any one user account.
+#
+# https://stackoverflow.com/questions/71849415/i-cannot-add-the-parent-directory-to-safe-directory-in-git
+# https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory
+# https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
+RUN git config --system --add safe.directory '*'
+
+# We skip setting a specific container user. This allows generating a
+# container with a bind-mounted path using Podman and explicitly specifying
+# `--user builduser:builduser` using Docker.
+#
+#USER builduser
+
+WORKDIR /builds
+COPY --chown=builduser:builduser . /builds

--- a/packages/dev/nfpm.yaml
+++ b/packages/dev/nfpm.yaml
@@ -1,0 +1,56 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# nfpm config file used for generating RPM and DEB packages.
+#
+# https://nfpm.goreleaser.com/usage/
+# https://nfpm.goreleaser.com/configuration/
+
+name: "check-path-dev"
+arch: "amd64"
+platform: "linux"
+
+# The SEMVER environment variable is set via the Makefile. Call `make
+# packages` to generate packages.
+version: ${SEMVER}
+
+section: "default"
+priority: "extra"
+maintainer: "Adam Chalkley <atc0005@users.noreply.github.com>"
+description: Various tools used to check/verify filesystem paths (dev build).
+vendor: "atc0005"
+homepage: "https://github.com/atc0005/check-path"
+license: "MIT"
+# changelog: "changelog.yaml"
+contents:
+  - src: ../../release_assets/check_path/check_path-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_path_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_path/check_path-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_path_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+overrides:
+  rpm:
+    depends:
+      # Provides selinuxenabled tool.
+      # Installed by default even via the "minimal" installation option.
+      - libselinux-utils
+    scripts:
+      # preinstall: ./scripts/rpm/preinstall.sh
+      postinstall: ./scripts/rpm/postinstall.sh
+      # postremove: ./scripts/rpm/postremove.sh
+  deb:
+    scripts:
+      # preinstall: ./scripts/deb/preinstall.sh
+      postinstall: ./scripts/deb/postinstall.sh
+      # preremove: ./scripts/deb/preremove.sh

--- a/packages/dev/scripts/deb/postinstall.sh
+++ b/packages/dev/scripts/deb/postinstall.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+project_org="atc0005"
+project_shortname="check-path"
+
+project_fq_name="${project_org}/${project_shortname}"
+project_url_base="https://github.com/${project_org}"
+project_repo="${project_url_base}/${project_shortname}"
+project_releases="${project_repo}/releases"
+project_issues="${project_repo}/issues"
+project_discussions="${project_repo}/discussions"
+
+plugin_name="check_path_dev"
+plugin_path="/usr/lib/nagios/plugins"
+
+echo
+echo "Thank you for installing packages provided by the ${project_fq_name} project!"
+echo
+echo "#######################################################################"
+echo "NOTE:"
+echo
+echo "This is a dev build; binaries installed by this package have a _dev"
+echo "suffix to allow installation alongside stable versions."
+echo
+echo "Feedback for all releases is welcome, but especially so for dev builds."
+echo "Thank you in advance!"
+echo "#######################################################################"
+echo
+echo "Project resources:"
+echo
+echo "- Obtain latest release: ${project_releases}"
+echo "- View/Ask questions: ${project_discussions}"
+echo "- View/Open issues: ${project_issues}"
+echo

--- a/packages/dev/scripts/rpm/postinstall.sh
+++ b/packages/dev/scripts/rpm/postinstall.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+project_org="atc0005"
+project_shortname="check-path"
+
+project_fq_name="${project_org}/${project_shortname}"
+project_url_base="https://github.com/${project_org}"
+project_repo="${project_url_base}/${project_shortname}"
+project_releases="${project_repo}/releases"
+project_issues="${project_repo}/issues"
+project_discussions="${project_repo}/discussions"
+
+plugin_name="check_path_dev"
+plugin_path="/usr/lib64/nagios/plugins"
+
+# Set required SELinux context to allow plugin use when SELinux is enabled.
+if [ -f "${plugin_path}/${plugin_name}" ]; then
+
+    # Make sure we can locate the selinuxenabled binary.
+    if [ -x "$(command -v selinuxenabled)" ]; then
+        selinuxenabled
+
+        if [ $? -ne 0 ]; then
+            echo -e "\nSELinux is not enabled, skipping application of contexts."
+        else
+            # SELinux is enabled. Set context.
+            echo -e "\nApplying SELinux contexts on ${plugin_path}/${plugin_name} ..."
+            chcon \
+                --verbose \
+                -t nagios_unconfined_plugin_exec_t \
+                -u system_u \
+                -r object_r \
+                ${plugin_path}/${plugin_name}
+
+            if [ $? -eq 0 ]; then
+                echo "Successfully applied SELinux contexts on ${plugin_path}/${plugin_name}"
+            else
+                echo "Failed to set SELinux contexts on ${plugin_path}/${plugin_name}"
+            fi
+        fi
+
+    else
+        echo "Error: Failed to locate selinuxenabled command." >&2
+    fi
+
+else
+    echo "${plugin_path}/${plugin_name} could not be found!"
+fi
+
+echo
+echo "Thank you for installing packages provided by the ${project_fq_name} project!"
+echo
+echo "#######################################################################"
+echo "NOTE:"
+echo
+echo "This is a dev build; binaries installed by this package have a _dev"
+echo "suffix to allow installation alongside stable versions."
+echo
+echo "Feedback for all releases is welcome, but especially so for dev builds."
+echo "Thank you in advance!"
+echo "#######################################################################"
+echo
+echo "Project resources:"
+echo
+echo "- Obtain latest release: ${project_releases}"
+echo "- View/Ask questions: ${project_discussions}"
+echo "- View/Open issues: ${project_issues}"
+echo

--- a/packages/stable/nfpm.yaml
+++ b/packages/stable/nfpm.yaml
@@ -1,0 +1,56 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# nfpm config file used for generating RPM and DEB packages.
+#
+# https://nfpm.goreleaser.com/usage/
+# https://nfpm.goreleaser.com/configuration/
+
+name: "check-path"
+arch: "amd64"
+platform: "linux"
+
+# The SEMVER environment variable is set via the Makefile. Call `make
+# packages` to generate packages.
+version: ${SEMVER}
+
+section: "default"
+priority: "extra"
+maintainer: "Adam Chalkley <atc0005@users.noreply.github.com>"
+description: Various tools used to check/verify filesystem paths.
+vendor: "atc0005"
+homepage: "https://github.com/atc0005/check-path"
+license: "MIT"
+# changelog: "changelog.yaml"
+contents:
+  - src: ../../release_assets/check_path/check_path-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_path
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_path/check_path-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_path
+    file_info:
+      mode: 0755
+    packager: deb
+
+overrides:
+  rpm:
+    depends:
+      # Provides selinuxenabled tool.
+      # Installed by default even via the "minimal" installation option.
+      - libselinux-utils
+    scripts:
+      # preinstall: ./scripts/rpm/preinstall.sh
+      postinstall: ./scripts/rpm/postinstall.sh
+      # postremove: ./scripts/rpm/postremove.sh
+  deb:
+    scripts:
+      # preinstall: ./scripts/deb/preinstall.sh
+      postinstall: ./scripts/deb/postinstall.sh
+      # preremove: ./scripts/deb/preremove.sh

--- a/packages/stable/scripts/deb/postinstall.sh
+++ b/packages/stable/scripts/deb/postinstall.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+project_org="atc0005"
+project_shortname="check-path"
+
+project_fq_name="${project_org}/${project_shortname}"
+project_url_base="https://github.com/${project_org}"
+project_repo="${project_url_base}/${project_shortname}"
+project_releases="${project_repo}/releases"
+project_issues="${project_repo}/issues"
+project_discussions="${project_repo}/discussions"
+
+plugin_name="check_path"
+plugin_path="/usr/lib/nagios/plugins"
+
+echo
+echo "Thank you for installing packages provided by the ${project_fq_name} project!"
+echo
+echo "Project resources:"
+echo
+echo "- Obtain latest release: ${project_releases}"
+echo "- View/Ask questions: ${project_discussions}"
+echo "- View/Open issues: ${project_issues}"
+echo

--- a/packages/stable/scripts/rpm/postinstall.sh
+++ b/packages/stable/scripts/rpm/postinstall.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-path
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+project_org="atc0005"
+project_shortname="check-path"
+
+project_fq_name="${project_org}/${project_shortname}"
+project_url_base="https://github.com/${project_org}"
+project_repo="${project_url_base}/${project_shortname}"
+project_releases="${project_repo}/releases"
+project_issues="${project_repo}/issues"
+project_discussions="${project_repo}/discussions"
+
+plugin_name="check_path"
+plugin_path="/usr/lib64/nagios/plugins"
+
+# Set required SELinux context to allow plugin use when SELinux is enabled.
+if [ -f "${plugin_path}/${plugin_name}" ]; then
+
+    # Make sure we can locate the selinuxenabled binary.
+    if [ -x "$(command -v selinuxenabled)" ]; then
+        selinuxenabled
+
+        if [ $? -ne 0 ]; then
+            echo -e "\nSELinux is not enabled, skipping application of contexts."
+        else
+            # SELinux is enabled. Set context.
+            echo -e "\nApplying SELinux contexts on ${plugin_path}/${plugin_name} ..."
+            chcon \
+                --verbose \
+                -t nagios_unconfined_plugin_exec_t \
+                -u system_u \
+                -r object_r \
+                ${plugin_path}/${plugin_name}
+
+            if [ $? -eq 0 ]; then
+                echo "Successfully applied SELinux contexts on ${plugin_path}/${plugin_name}"
+            else
+                echo "Failed to set SELinux contexts on ${plugin_path}/${plugin_name}"
+            fi
+        fi
+
+    else
+        echo "Error: Failed to locate selinuxenabled command." >&2
+    fi
+
+else
+    echo "${plugin_path}/${plugin_name} could not be found!"
+fi
+
+echo
+echo "Thank you for installing packages provided by the ${project_fq_name} project!"
+echo
+echo "Project resources:"
+echo
+echo "- Obtain latest release: ${project_releases}"
+echo "- View/Ask questions: ${project_discussions}"
+echo "- View/Open issues: ${project_issues}"
+echo


### PR DESCRIPTION
## Changes

- Switch to semantic versioning (semver) compatible versioning pattern
  - filenames (where applicable)
  - embedded version metadata
- Generate RPM/DEB packages using nFPM
  - "stable" release packages
  - "dev" release packages
    - provides binaries with `_dev` suffix in order to more easily test the impact of new releases
- Add version metadata to Windows executables
  - Use `github.com/tc-hib/go-winres` and `winres.json` file to apply version details to Windows executables provided by this project
  - update `.gitignore` to exclude Windows syso files
    - these files are produced when running go generate as part of the build process and should not be retained in version control
- Makefile: Compress binaries and use fixed filenames
- Makefile: Refresh recipes to add "standard" set, new package-related options
- Build dev/stable releases using go-ci Docker image
- Add Dockerfile to provide "builder" image for Makefile-driven release builds
  - copy project/repo content into container at build time - explicitly changing owner:group to `builduser`
  - explicitly create new `builduser` user and group
    - this is explicitly used for Docker-based builds
  - set `/builds` as the working directory
  - set Git `safe.directory` logic at system level
- Add new `.dockerignore` file to exclude unnecessary items from build image generation
- Update Dependabot configuration to add update monitoring for `go-ci-oldstable-build` image
- Update/Add Makefile recipes
  - add separate docker/podman variants of container-based project build recipes - each uses slightly different logic to achieve rootless container execution - new recipes - `docker-release-build` - `docker-dev-build` - `docker-packages` - `podman-release-build` - `podman-dev-build` - `podman-packages`
  - explicitly emit the tool used to perform specific tasks
    - this can be useful to help explain why a generated builder image does not appear in the `docker image ls` output as a sysadmin might expect (if it was instead built with the `docker` command)
  - rename/remove the helper build recipe from the `help` recipe output (not useful to call directly)
  - to explicitly run the build container as the `builduser` user that is created during build image generation when using Docker to build/run containers (Podman uses different settings)
  - to send `xz` compressed output to stdout, then redirect to a target file
    - this works around failures to `chmod` and `chgrp` the compressed copy of input files when run within a non-root container
  - to explicitly bind mount the `release_assets` path into `/builds/release_assets` (using the same Makefile variable) read/write (instead of relying on implied read/write access)
  - to explicitly use `/builds` as the working directory
- Update README
  - note decompression step needed after downloading individual binaries or building via some Makefile recipes
  - note DEB and RPM packages as alternatives to downloading individual binaries

This collection of changes allows reliably building this project using either Docker or Podman via a "rootless" container.

## References

- fixes GH-179
- fixes GH-180
- fixes GH-181
- fixes GH-182
- fixes GH-183
- fixes GH-184