### PR TITLE
Update build tags syntax

### DIFF
--- a/cmd/ugs/main-unix.go
+++ b/cmd/ugs/main-unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright 2020 Adam Chalkley
 //

--- a/cmd/ugs/main-windows.go
+++ b/cmd/ugs/main-windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright 2020 Adam Chalkley
 //

--- a/internal/config/validate-unix.go
+++ b/internal/config/validate-unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright 2020 Adam Chalkley
 //

--- a/internal/config/validate-windows.go
+++ b/internal/config/validate-windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright 2020 Adam Chalkley
 //

--- a/internal/paths/ids-unix.go
+++ b/internal/paths/ids-unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Copyright 2020 Adam Chalkley
 //

--- a/internal/paths/ids-windows.go
+++ b/internal/paths/ids-windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Copyright 2020 Adam Chalkley
 //


### PR DESCRIPTION
Drop older build tags as we're updating the minimum Go version in this project's go.mod file (soon).